### PR TITLE
Add automatic processing to results for a small number of label regexp

### DIFF
--- a/robotoff/insights/ocr/dataclass.py
+++ b/robotoff/insights/ocr/dataclass.py
@@ -28,13 +28,15 @@ class OCRRegex:
                  lowercase: bool = False,
                  processing_func: Optional[Callable] = None,
                  priority: Optional[int] = None,
-                 notify: bool = False):
+                 notify: bool = False,
+                 trust: float = 1):
         self.regex = regex
         self.field: OCRField = field
         self.lowercase: bool = lowercase
         self.processing_func: Optional[Callable] = processing_func
         self.priority = priority
         self.notify = notify
+        self.trust = trust
 
 
 class ImageOrientation(enum.Enum):

--- a/robotoff/insights/ocr/label.py
+++ b/robotoff/insights/ocr/label.py
@@ -149,13 +149,15 @@ LABELS_REGEX = {
             re.compile(
                 r"australian made|made in australia|fabriqu[ée] en australie|geproduceerd in australi[ëe]|fabricado en australia"),
             field=OCRField.full_text_contiguous,
-            lowercase=True),
+            lowercase=True,
+            trust=1.5),
     ],
     'en:gluten-free': [
         OCRRegex(
             re.compile(r"(?<!\w)(?:sans|ni) gluten|gluten[- ]free|glutenvrij|senza glutine|sin gluten|glutenfrei|sem gluten|gluténmentes|bez lepku|не містить глютену|bezglutenomy|без глютена"),
             field=OCRField.full_text_contiguous,
-            lowercase=True),
+            lowercase=True,
+            trust=1.5),
     ],
     'en:no-preservatives': [
         OCRRegex(
@@ -182,7 +184,8 @@ LABELS_REGEX = {
             re.compile(
                 r"(?<!\w)(?:vegan|v[ée]g[ée]talien|vegano|veganistisch)(?!\w)"),
             field=OCRField.full_text_contiguous,
-            lowercase=True),
+            lowercase=True,
+            trust=1.5),
     ],
     'en:no-colorings': [
         OCRRegex(
@@ -296,6 +299,7 @@ def find_labels(ocr_result: OCRResult) -> List[Dict]:
                     'label_tag': label_value,
                     'text': match.group(),
                     'notify': ocr_regex.notify,
+                    'automatic_processing': ocr_regex.trust > 1
                 })
 
     for logo_annotation in ocr_result.logo_annotations:


### PR DESCRIPTION
Treat this more as psuedocode; completely 100% untested locally.

Adds a 'trust' weighting to OCRRegexp instances, to allow some to be high trust, others to be low trust; and to decide if automatic processing is appropriate.

This is based on my subjective observations of the various labels only, open to stats to set more realistic limits.