### PR TITLE
Fix store name

### DIFF
--- a/data/ocr/regex_stores.txt
+++ b/data/ocr/regex_stores.txt
@@ -176,4 +176,4 @@ REWE
 Sainsbury's
 Tesco
 Waitrose
-Woolworth||woolworths?
+Woolworths||woolworths?


### PR DESCRIPTION
Australian brand/store is known as 'Woolworths' (https://en.wikipedia.org/wiki/Woolworths_Supermarkets)

On deploy, probably need to do a migration of anything that ends back up in https://au.openfoodfacts.org/store/woolworth