### PR TITLE
Add Cora and Match as stores for Patrimoine Gourmand brand

### DIFF
--- a/data/ocr/store_regex.txt
+++ b/data/ocr/store_regex.txt
@@ -172,8 +172,8 @@ Migros
 Monoprix
 Morrisson's
 Picard
-Cora||Patrimoine gourmand
-Match||Patrimoine gourmand
+Cora||patrimoine gourmand
+Match||patrimoine gourmand
 REWE
 Sainsbury's
 Tesco

--- a/data/ocr/store_regex.txt
+++ b/data/ocr/store_regex.txt
@@ -172,6 +172,8 @@ Migros
 Monoprix
 Morrisson's
 Picard
+Cora||Patrimoine gourmand
+Match||Patrimoine gourmand
 REWE
 Sainsbury's
 Tesco


### PR DESCRIPTION
Add Cora and Match as stores for Patrimoine Gourmand brand