### PR TITLE
Update the Sentry SDK

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ falcon-multipart==0.2.0
 elasticsearch==6.3.1
 Click==7.1.2
 apscheduler==3.6.3
-sentry-sdk[falcon]==0.14.4
+sentry-sdk[falcon]==0.19.5
 Pillow==7.1.2
 more-itertools==8.3.0
 numpy==1.18.4


### PR DESCRIPTION
### What
Update sentry.python from @v0.14.4 to @0.19.5

### Part of
- [ ] Keep dependancies up to date
