### PR TITLE
Fix test_categories.py

### DIFF
--- a/doc/introduction/contributing.md
+++ b/doc/introduction/contributing.md
@@ -60,10 +60,10 @@ development.
     poetry install
     ```
 
-4.  Launch the PostgreSQL database using docker-compose:
+4.  Download the Robotoff models(required by some tests)
 
     ```
-    docker-compose up -d postgres
+    poetry run robotoff-cli download-models
     ```
 
 5.  Create a branch for local development:

--- a/robotoff/cli/annotate.py
+++ b/robotoff/cli/annotate.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional
 
 import click
 
+from robotoff import settings
 from robotoff.utils import http_session
 from robotoff.utils.types import JSONType
 
@@ -12,11 +13,10 @@ LOCAL = False
 if LOCAL:
     BASE_URL = "http://localhost:5500/api/v1"
 else:
-    BASE_URL = "https://robotoff.openfoodfacts.org/api/v1"
+    BASE_URL = OFF_BASE_WEBSITE_URL + "/api/v1"
 
 RANDOM_INSIGHT_URL = BASE_URL + "/insights/random"
 ANNOTATE_INSIGHT_URL = BASE_URL + "/insights/annotate"
-STATIC_IMAGE_DIR_URL = "https://static.openfoodfacts.org/images/products"
 
 
 class NoInsightException(Exception):
@@ -101,7 +101,7 @@ def print_generic_insight(insight: JSONType) -> None:
     )
 
     if "source" in insight:
-        click.echo("image: {}{}".format(STATIC_IMAGE_DIR_URL, insight["source"]))
+        click.echo("image: {}{}".format(settings.OFF_IMAGE_BASE_URL, insight["source"]))
     click.echo("")
 
 

--- a/robotoff/cli/annotate.py
+++ b/robotoff/cli/annotate.py
@@ -13,7 +13,7 @@ LOCAL = False
 if LOCAL:
     BASE_URL = "http://localhost:5500/api/v1"
 else:
-    BASE_URL = OFF_BASE_WEBSITE_URL + "/api/v1"
+    BASE_URL = settings.BaseURLProvider().get() + "/api/v1"
 
 RANDOM_INSIGHT_URL = BASE_URL + "/insights/random"
 ANNOTATE_INSIGHT_URL = BASE_URL + "/insights/annotate"
@@ -96,7 +96,8 @@ def print_generic_insight(insight: JSONType) -> None:
 
     click.echo(
         "url: {}".format(
-            "https://fr.openfoodfacts.org/produit/" "{}".format(insight["barcode"])
+            "https://fr.openfoodfacts.org/produit/"
+            "{}".format(insight["barcode"])  # still hardcoded
         )
     )
 
@@ -112,7 +113,8 @@ def print_ingredient_spellcheck_insight(insight: JSONType) -> None:
 
     click.echo(
         "url: {}".format(
-            "https://fr.openfoodfacts.org/produit/" "{}".format(insight["barcode"])
+            "https://fr.openfoodfacts.org/produit/"
+            "{}".format(insight["barcode"])  # still hardcoded
         )
     )
 

--- a/robotoff/cli/annotate.py
+++ b/robotoff/cli/annotate.py
@@ -13,7 +13,7 @@ LOCAL = False
 if LOCAL:
     BASE_URL = "http://localhost:5500/api/v1"
 else:
-    BASE_URL = settings.BaseURLProvider().get() + "/api/v1"
+    BASE_URL = settings.BaseURLProvider().robotoff().get() + "/api/v1"
 
 RANDOM_INSIGHT_URL = BASE_URL + "/insights/random"
 ANNOTATE_INSIGHT_URL = BASE_URL + "/insights/annotate"
@@ -95,10 +95,9 @@ def print_generic_insight(insight: JSONType) -> None:
         click.echo("{}: {}".format(key, str(value)))
 
     click.echo(
-        "url: {}".format(
-            "https://fr.openfoodfacts.org/produit/"
-            "{}".format(insight["barcode"])  # still hardcoded
-        )
+        "url: {}/produit/{}".format(
+            settings.BaseURLProvider().country("fr").get(), insight["barcode"]
+        )  # still hardcoded
     )
 
     if "source" in insight:
@@ -112,10 +111,9 @@ def print_ingredient_spellcheck_insight(insight: JSONType) -> None:
         click.echo("{}: {}".format(key, str(value)))
 
     click.echo(
-        "url: {}".format(
-            "https://fr.openfoodfacts.org/produit/"
-            "{}".format(insight["barcode"])  # still hardcoded
-        )
+        "url: {}/produit/{}".format(
+            settings.BaseURLProvider().country("fr").get(), insight["barcode"]
+        )  # still hardcoded
     )
 
     original_snippet = insight["original_snippet"]

--- a/robotoff/cli/batch.py
+++ b/robotoff/cli/batch.py
@@ -47,7 +47,7 @@ def batch_annotate(
             i += 1
             print("Insight %d" % i)
             print(
-                "Add label {} to https://fr.openfoodfacts.org/produit/{}"
+                "Add label {} to https://fr.openfoodfacts.org/produit/{}"  # still hardcoded.
                 "".format(insight.data, insight.barcode)
             )
             print(insight.data)

--- a/robotoff/cli/batch.py
+++ b/robotoff/cli/batch.py
@@ -3,6 +3,7 @@ from typing import Dict, Optional
 
 from robotoff.insights.annotate import InsightAnnotatorFactory
 from robotoff.models import ProductInsight
+from robotoff.settings import BaseURLProvider
 
 
 def run(insight_type: str, dry: bool = True, json_contains_str: Optional[str] = None):
@@ -47,8 +48,10 @@ def batch_annotate(
             i += 1
             print("Insight %d" % i)
             print(
-                "Add label {} to https://fr.openfoodfacts.org/produit/{}"  # still hardcoded.
-                "".format(insight.data, insight.barcode)
+                "Add label {} to {}/produit/{}"
+                "".format(
+                    insight.data, BaseURLProvider().country("fr").get(), insight.barcode
+                )
             )
             print(insight.data)
 

--- a/robotoff/cli/spellcheck.py
+++ b/robotoff/cli/spellcheck.py
@@ -27,7 +27,7 @@ def correct_ingredient(
         barcode = product.get("code")
         print(
             "Fixing {}/product/{}".format(
-                BaseURLProvider().country("fr").get(), barcode
+                BaseURLProvider().country(country).get(), barcode
             )
         )
         product = get_product(barcode, fields=[ingredient_field])

--- a/robotoff/cli/spellcheck.py
+++ b/robotoff/cli/spellcheck.py
@@ -2,6 +2,7 @@ import re
 from typing import List
 
 from robotoff.off import OFFAuthentication, get_product, save_ingredients
+from robotoff.settings import BaseURLProvider
 from robotoff.utils import http_session
 
 
@@ -24,7 +25,11 @@ def correct_ingredient(
 
     for product in products:
         barcode = product.get("code")
-        print("Fixing https://{}.openfoodfacts.org/product/{}".format(country, barcode))
+        print(
+            "Fixing {}/product/{}".format(
+                BaseURLProvider().country("fr").get(), barcode
+            )
+        )
         product = get_product(barcode, fields=[ingredient_field])
 
         if product is None:
@@ -65,7 +70,7 @@ def get_patterns(pattern: str, correction: str) -> List:
 
 def iter_products(country: str, ingredient: str):
     ingredient_field = f"ingredients_text_{country}"
-    base_url = f"https://{country}.openfoodfacts.org/ingredient"
+    base_url = BaseURLProvider().country(country) + "/ingredient"
     url = base_url + f"/{ingredient}/1.json?fields=code,{ingredient_field}"
     r = http_session.get(url)
     data = r.json()

--- a/robotoff/cli/spellcheck.py
+++ b/robotoff/cli/spellcheck.py
@@ -70,7 +70,7 @@ def get_patterns(pattern: str, correction: str) -> List:
 
 def iter_products(country: str, ingredient: str):
     ingredient_field = f"ingredients_text_{country}"
-    base_url = BaseURLProvider().country(country) + "/ingredient"
+    base_url = BaseURLProvider().country(country).get() + "/ingredient"
     url = base_url + f"/{ingredient}/1.json?fields=code,{ingredient_field}"
     r = http_session.get(url)
     data = r.json()

--- a/robotoff/logos.py
+++ b/robotoff/logos.py
@@ -43,7 +43,7 @@ LOGO_CONFIDENCE_THRESHOLDS = CachedStore(
 
 def get_stored_logo_ids() -> Set[int]:
     r = http_session.get(
-        settings.ROBOTOFF_BASE_WEBSITE_URL + "/api/v1/ann/stored", timeout=30
+        settings.BaseURLProvider().get() + "/api/v1/ann/stored", timeout=30
     )
 
     if not r.ok:
@@ -66,7 +66,7 @@ def add_logos_to_ann(image: ImageModel, logos: List[LogoAnnotation]) -> int:
         "logos": [{"bounding_box": logo.bounding_box, "id": logo.id} for logo in logos],
     }
     r = http_session.post(
-        settings.ROBOTOFF_BASE_WEBSITE_URL + "/api/v1/ann/add", json=data, timeout=30
+        settings.BaseURLProvider().robotoff().get() + "/api/v1/ann/add", json=data, timeout=30
     )
 
     if not r.ok:
@@ -79,7 +79,9 @@ def add_logos_to_ann(image: ImageModel, logos: List[LogoAnnotation]) -> int:
 def save_nearest_neighbors(logos: List[LogoAnnotation]) -> int:
     logo_ids_params = ",".join((str(logo.id) for logo in logos))
     r = http_session.get(
-        settings.ROBOTOFF_BASE_WEBSITE_URL + "/api/v1/ann/batch?logo_ids=" + logo_ids_params,
+        settings.BaseURLProvider().robotoff().get()
+        + "/api/v1/ann/batch?logo_ids="
+        + logo_ids_params,
         timeout=30,
     )
 
@@ -382,7 +384,7 @@ def send_logo_notification(logo: LogoAnnotation, probs: Dict[LogoLabelType, floa
         )
     )
     barcode = logo.image_prediction.image.barcode
-    base_off_url = settings.ROBOTOFF_BASE_WEBSITE_URL
+    base_off_url = settings.BaseURLProvider().get()
     text = (
         f"Prediction for <{crop_url}|image> "
         f"(<https://hunger.openfoodfacts.org/logos?logo_id={logo.id}|annotate logo>, "

--- a/robotoff/logos.py
+++ b/robotoff/logos.py
@@ -43,7 +43,7 @@ LOGO_CONFIDENCE_THRESHOLDS = CachedStore(
 
 def get_stored_logo_ids() -> Set[int]:
     r = http_session.get(
-        "https://robotoff.openfoodfacts.org/api/v1/ann/stored", timeout=30
+        settings.ROBOTOFF_BASE_WEBSITE_URL + "/api/v1/ann/stored", timeout=30
     )
 
     if not r.ok:
@@ -66,7 +66,7 @@ def add_logos_to_ann(image: ImageModel, logos: List[LogoAnnotation]) -> int:
         "logos": [{"bounding_box": logo.bounding_box, "id": logo.id} for logo in logos],
     }
     r = http_session.post(
-        "https://robotoff.openfoodfacts.org/api/v1/ann/add", json=data, timeout=30
+        settings.ROBOTOFF_BASE_WEBSITE_URL + "/api/v1/ann/add", json=data, timeout=30
     )
 
     if not r.ok:
@@ -79,7 +79,7 @@ def add_logos_to_ann(image: ImageModel, logos: List[LogoAnnotation]) -> int:
 def save_nearest_neighbors(logos: List[LogoAnnotation]) -> int:
     logo_ids_params = ",".join((str(logo.id) for logo in logos))
     r = http_session.get(
-        f"https://robotoff.openfoodfacts.org/api/v1/ann/batch?logo_ids={logo_ids_params}",
+        settings.ROBOTOFF_BASE_WEBSITE_URL + "/api/v1/ann/batch?logo_ids=" + logo_ids_params,
         timeout=30,
     )
 
@@ -382,9 +382,10 @@ def send_logo_notification(logo: LogoAnnotation, probs: Dict[LogoLabelType, floa
         )
     )
     barcode = logo.image_prediction.image.barcode
+    base_off_url = settings.ROBOTOFF_BASE_WEBSITE_URL
     text = (
         f"Prediction for <{crop_url}|image> "
         f"(<https://hunger.openfoodfacts.org/logos?logo_id={logo.id}|annotate logo>, "
-        f"<https://world.openfoodfacts.org/product/{barcode}|product>):\n{prob_text}"
+        f"<{base_off_url}/product/{barcode}|product>):\n{prob_text}"
     )
     post_message(text, settings.SLACK_OFF_ROBOTOFF_ALERT_CHANNEL)

--- a/robotoff/logos.py
+++ b/robotoff/logos.py
@@ -43,7 +43,7 @@ LOGO_CONFIDENCE_THRESHOLDS = CachedStore(
 
 def get_stored_logo_ids() -> Set[int]:
     r = http_session.get(
-        settings.BaseURLProvider().get() + "/api/v1/ann/stored", timeout=30
+        settings.BaseURLProvider().robotoff().get() + "/api/v1/ann/stored", timeout=30
     )
 
     if not r.ok:
@@ -66,7 +66,9 @@ def add_logos_to_ann(image: ImageModel, logos: List[LogoAnnotation]) -> int:
         "logos": [{"bounding_box": logo.bounding_box, "id": logo.id} for logo in logos],
     }
     r = http_session.post(
-        settings.BaseURLProvider().robotoff().get() + "/api/v1/ann/add", json=data, timeout=30
+        settings.BaseURLProvider().robotoff().get() + "/api/v1/ann/add",
+        json=data,
+        timeout=30,
     )
 
     if not r.ok:

--- a/robotoff/metrics.py
+++ b/robotoff/metrics.py
@@ -74,7 +74,9 @@ def get_influx_client() -> InfluxDBClient:
 
 def get_product_count(country_tag: str) -> int:
     r = requests.get(
-        "https://{}.openfoodfacts.org/3.json?fields=null".format(country_tag)
+        "https://{}.openfoodfacts.org/3.json?fields=null".format(
+            country_tag
+        )  # still hardcoded
     ).json()
     return int(r["count"])
 
@@ -122,7 +124,7 @@ def generate_metrics_from_path(
     facet: Optional[str] = None,
 ) -> List:
     inserts: List = []
-    url = f"https://{country_tag}-en.openfoodfacts.org{path}"
+    url = f"https://{country_tag}-en.openfoodfacts.org{path}"  # still hardcoded
 
     if facet is None:
         facet = get_facet_name(url)

--- a/robotoff/metrics.py
+++ b/robotoff/metrics.py
@@ -74,9 +74,7 @@ def get_influx_client() -> InfluxDBClient:
 
 def get_product_count(country_tag: str) -> int:
     r = requests.get(
-        "https://{}.openfoodfacts.org/3.json?fields=null".format(
-            country_tag
-        )  # still hardcoded
+        settings.BaseURLProvider().country(country_tag).get() + "/3.json?fields=null"
     ).json()
     return int(r["count"])
 
@@ -124,7 +122,7 @@ def generate_metrics_from_path(
     facet: Optional[str] = None,
 ) -> List:
     inserts: List = []
-    url = f"https://{country_tag}-en.openfoodfacts.org{path}"  # still hardcoded
+    url = settings.BaseURLProvider().country(country_tag + "-en").get() + path
 
     if facet is None:
         facet = get_facet_name(url)

--- a/robotoff/ml/category/prediction_from_ocr/constants.py
+++ b/robotoff/ml/category/prediction_from_ocr/constants.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 # TODO: move all weights file paths definition in the same place.
 # Model an be downloaded from the CLI.
-RIDGE_PREDICTOR_URL = "https://github.com/openfoodfacts/robotoff-models/releases/latest/download/bestridge_compressed.joblib"
+# Temporary fix the model URL to a specific release.
+RIDGE_PREDICTOR_URL = "https://github.com/openfoodfacts/robotoff-models/releases/download/category-predictor-ocr-lewagon-1.0/bestridge_compressed.joblib"
 RIDGE_PREDICTOR_FILEPATH = Path("weights/bestridge_compressed.joblib")
 
 LIST_CATEGORIES = [

--- a/robotoff/off.py
+++ b/robotoff/off.py
@@ -66,7 +66,7 @@ AUTH_DICT = {
 }
 
 API_URLS: Dict[ServerType, str] = {
-    ServerType.off: "https://world.openfoodfacts.org",
+    ServerType.off: settings.BaseURLProvider().get(),
     ServerType.obf: "https://world.openbeautyfacts.org",
     ServerType.opf: "https://world.openproductfacts.org",
     ServerType.opff: "https://world.openpetfoodfacts.org",
@@ -399,7 +399,7 @@ def move_to(barcode: str, to: ServerType, timeout: Optional[int] = 10) -> bool:
     if get_product(barcode, server=to) is not None:
         return False
 
-    url = "{}/cgi/product_jqm.pl".format(settings.OFF_BASE_WEBSITE_URL)
+    url = "{}/cgi/product_jqm.pl".format(settings.BaseURLProvider().get())
     params = {
         "type": "edit",
         "code": barcode,

--- a/robotoff/settings.py
+++ b/robotoff/settings.py
@@ -72,7 +72,6 @@ TAXONOMY_BRAND_URL = (
 )
 OFF_IMAGE_BASE_URL = BaseURLProvider().static().get() + "/images/products"
 
-OFF_BASE_WEBSITE_URL = "https://world.openfoodfacts.org"
 OFF_BRANDS_URL = BaseURLProvider().get() + "/brands.json"
 
 OFF_PASSWORD = os.environ.get("OFF_PASSWORD", "")

--- a/robotoff/settings.py
+++ b/robotoff/settings.py
@@ -27,6 +27,7 @@ TAXONOMY_INGREDIENT_URL = (
 TAXONOMY_LABEL_URL = "https://static.openfoodfacts.org/data/taxonomies/labels.full.json"
 TAXONOMY_BRAND_URL = "https://static.openfoodfacts.org/data/taxonomies/brands.full.json"
 OFF_IMAGE_BASE_URL = "https://static.openfoodfacts.org/images/products"
+
 OFF_BASE_WEBSITE_URL = "https://world.openfoodfacts.org"
 OFF_BRANDS_URL = OFF_BASE_WEBSITE_URL + "/brands.json"
 

--- a/robotoff/settings.py
+++ b/robotoff/settings.py
@@ -2,6 +2,46 @@ import os
 from pathlib import Path
 from typing import Tuple
 
+# Should be either 'prod' or 'dev'.
+_robotoff_instance = os.environ.get("ROBOTOFF_INSTANCE", "prod")
+
+if _robotoff_instance != "prod" and _robotoff_instance != "dev":
+    raise ValueError(
+        "ROBOTOFF_INSTANCE should be either 'prod' or 'dev', got %s"
+        % _robotoff_instance
+    )
+
+
+class BaseURLProvider(object):
+    """BaseURLProvider allows to fetch a base URL for Product Opener/Robotoff.
+
+    Example usage: BaseURLProvider().robotoff().get() returns the Robotoff URL.
+    """
+
+    def __init__(self):
+        suffix = "org"
+        if _robotoff_instance == "dev":
+            suffix = "net"
+
+        self.url = "https://%(prefix)s.openfoodfacts." + suffix
+        self.prefix = "world"
+
+    def robotoff(self):
+        self.prefix = "robotoff"
+        return self
+
+    def static(self):
+        self.prefix = "static"
+        return self
+
+    def country(self, country_code: str):
+        self.prefix = country_code
+        return self
+
+    def get(self):
+        return self.url % {"prefix": self.prefix}
+
+
 PROJECT_DIR = Path(__file__).parent.parent
 DATA_DIR = PROJECT_DIR / "data"
 DATASET_DIR = PROJECT_DIR / "datasets"
@@ -15,21 +55,25 @@ DATASET_CHECK_MIN_PRODUCT_COUNT = 1000000
 INSIGHT_DUMP_PATH = DATASET_DIR / "insights.jsonl.gz"
 
 JSONL_DATASET_URL = (
-    "https://static.openfoodfacts.org/data/openfoodfacts-products.jsonl.gz"
+    BaseURLProvider().static().get() + "/data/openfoodfacts-products.jsonl.gz"
 )
 
 TAXONOMY_CATEGORY_URL = (
-    "https://static.openfoodfacts.org/data/taxonomies/categories.full.json"
+    BaseURLProvider().static().get() + "/data/taxonomies/categories.full.json"
 )
 TAXONOMY_INGREDIENT_URL = (
-    "https://static.openfoodfacts.org/data/taxonomies/ingredients.full.json"
+    BaseURLProvider().static().get() + "/data/taxonomies/ingredients.full.json"
 )
-TAXONOMY_LABEL_URL = "https://static.openfoodfacts.org/data/taxonomies/labels.full.json"
-TAXONOMY_BRAND_URL = "https://static.openfoodfacts.org/data/taxonomies/brands.full.json"
-OFF_IMAGE_BASE_URL = "https://static.openfoodfacts.org/images/products"
+TAXONOMY_LABEL_URL = (
+    BaseURLProvider().static().get() + "/data/taxonomies/labels.full.json"
+)
+TAXONOMY_BRAND_URL = (
+    BaseURLProvider().static().get() + "/data/taxonomies/brands.full.json"
+)
+OFF_IMAGE_BASE_URL = BaseURLProvider().static().get() + "/images/products"
 
 OFF_BASE_WEBSITE_URL = "https://world.openfoodfacts.org"
-OFF_BRANDS_URL = OFF_BASE_WEBSITE_URL + "/brands.json"
+OFF_BRANDS_URL = BaseURLProvider().get() + "/brands.json"
 
 OFF_PASSWORD = os.environ.get("OFF_PASSWORD", "")
 OFF_SERVER_DOMAIN = "api.openfoodfacts.org"

--- a/robotoff/slack.py
+++ b/robotoff/slack.py
@@ -76,7 +76,7 @@ def notify_image_flag(insights: List[RawInsight], source: str, barcode: str):
 
     url = settings.OFF_IMAGE_BASE_URL + source
     edit_url = "{}/cgi/product.pl?type=edit&code={}" "".format(
-        settings.OFF_BASE_WEBSITE_URL, barcode
+        settings.BaseURLProvider().get(), barcode
     )
     text += url + "\n"
     text += "edit: {}".format(edit_url)
@@ -85,11 +85,15 @@ def notify_image_flag(insights: List[RawInsight], source: str, barcode: str):
 
 
 def notify_automatic_processing(insight: ProductInsight):
-    product_url = "{}/product/{}".format(settings.OFF_BASE_WEBSITE_URL, insight.barcode)
+    product_url = "{}/product/{}".format(
+        settings.BaseURLProvider().get(), insight.barcode
+    )
     source_image = insight.source_image
 
     if source_image:
-        image_url = "https://static.openfoodfacts.org/images/products" + source_image
+        image_url = (
+            "https://static.openfoodfacts.org/images/products" + source_image
+        )  # still hardcoded
         metadata_text = "(<{}|product>, <{}|source image>)".format(
             product_url, image_url
         )

--- a/robotoff/slack.py
+++ b/robotoff/slack.py
@@ -92,8 +92,8 @@ def notify_automatic_processing(insight: ProductInsight):
 
     if source_image:
         image_url = (
-            "https://static.openfoodfacts.org/images/products" + source_image
-        )  # still hardcoded
+            settings.BaseURLProvider().static() + "/images/products" + source_image
+        )
         metadata_text = "(<{}|product>, <{}|source image>)".format(
             product_url, image_url
         )

--- a/robotoff/workers/tasks/update_recycle.py
+++ b/robotoff/workers/tasks/update_recycle.py
@@ -1,9 +1,9 @@
 from typing import Dict
 
-from robotoff import settings
 from robotoff.insights.extraction import get_logger, requests
 from robotoff.insights.ocr.core import get_json_for_image
 from robotoff.products import ProductDataset
+from robotoff.settings import BaseURLProvider
 
 logger = get_logger(__name__)
 
@@ -56,9 +56,7 @@ def get_images(ean: str) -> Dict:
     Get images for the product
     """
 
-    url = (
-        settings.OFF_BASE_WEBSITE_URL + "/api/v0/product/" + ean + ".json?fields=images"
-    )
+    url = BaseURLProvider().get() + "/api/v0/product/" + ean + ".json?fields=images"
     try:
         result = requests.get(url)
         if result.ok:
@@ -129,7 +127,7 @@ def unselect_image(barcode: str, field_name: str, username: str, password: str) 
     Unselect image for product
     """
 
-    url = settings.OFF_BASE_WEBSITE_URL + "/cgi/product_image_unselect.pl"
+    url = BaseURLProvider().get() + "/cgi/product_image_unselect.pl"
     data = {
         "code": barcode,
         "id": field_name,
@@ -153,7 +151,7 @@ def reselect_image(
     Select image for product
     """
 
-    url = settings.OFF_BASE_WEBSITE_URL + "/cgi/product_image_crop.pl"
+    url = BaseURLProvider().get() + "/cgi/product_image_crop.pl"
     data = {
         "code": barcode,
         "imgid": img_id,

--- a/robotoff/workers/tasks/update_recycle.py
+++ b/robotoff/workers/tasks/update_recycle.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+from robotoff import settings
 from robotoff.insights.extraction import get_logger, requests
 from robotoff.insights.ocr.core import get_json_for_image
 from robotoff.products import ProductDataset
@@ -56,7 +57,7 @@ def get_images(ean: str) -> Dict:
     """
 
     url = (
-        "https://world.openfoodfacts.org/api/v0/product/" + ean + ".json?fields=images"
+        settings.OFF_BASE_WEBSITE_URL + "/api/v0/product/" + ean + ".json?fields=images"
     )
     try:
         result = requests.get(url)
@@ -128,7 +129,7 @@ def unselect_image(barcode: str, field_name: str, username: str, password: str) 
     Unselect image for product
     """
 
-    url = "https://world.openfoodfacts.org/cgi/product_image_unselect.pl"
+    url = settings.OFF_BASE_WEBSITE_URL + "/cgi/product_image_unselect.pl"
     data = {
         "code": barcode,
         "id": field_name,
@@ -152,7 +153,7 @@ def reselect_image(
     Select image for product
     """
 
-    url = "https://world.openfoodfacts.org/cgi/product_image_crop.pl"
+    url = settings.OFF_BASE_WEBSITE_URL + "/cgi/product_image_crop.pl"
     data = {
         "code": barcode,
         "imgid": img_id,


### PR DESCRIPTION
The failing test is fixed by forcing the cli to read from a particular release, until we have a better story for how the models are released uniformly.

One of the questions I see is why we need this model for a unit test in the first place - ideally you would have a smaller, mock model in order to test the functionality of the predictor rather than using a heavy production model that needs to be fetched from somewhere.