### PR TITLE
Fix test_categories.py

### DIFF
--- a/doc/introduction/contributing.md
+++ b/doc/introduction/contributing.md
@@ -60,10 +60,10 @@ development.
     poetry install
     ```
 
-4.  Launch the PostgreSQL database using docker-compose:
+4.  Download the Robotoff models(required by some tests):
 
     ```
-    docker-compose up -d postgres
+    poetry run robotoff-cli download-models
     ```
 
 5.  Create a branch for local development:

--- a/robotoff/ml/category/prediction_from_ocr/constants.py
+++ b/robotoff/ml/category/prediction_from_ocr/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 # TODO: move all weights file paths definition in the same place.
 # Model an be downloaded from the CLI.
-RIDGE_PREDICTOR_URL = "https://github.com/openfoodfacts/robotoff-models/releases/latest/download/bestridge_compressed.joblib"
+RIDGE_PREDICTOR_URL = "https://github.com/openfoodfacts/robotoff-models/releases/download/category-predictor-ocr-lewagon-1.0/bestridge_compressed.joblib"
 RIDGE_PREDICTOR_FILEPATH = Path("weights/bestridge_compressed.joblib")
 
 LIST_CATEGORIES = [


### PR DESCRIPTION
The failing test is fixed by forcing the cli to read from a particular release, until we have a better story for how the models are released uniformly.

One of the questions I see is why we need this model for a unit test in the first place - ideally you would have a smaller, mock model in order to test the functionality of the predictor rather than using a heavy production model that needs to be fetched from somewhere.