### PR TITLE
Add last missing instruction needed for the test to run locally.

### DIFF
--- a/doc/introduction/contributing.md
+++ b/doc/introduction/contributing.md
@@ -60,10 +60,16 @@ development.
     poetry install
     ```
 
-4.  Download the Robotoff models(required by some tests):
-
+4.  Configure files required for the tests to run locally:
+    
+    Download the Robotoff models:
     ```
     poetry run robotoff-cli download-models
+    ```
+
+    Compile the i18n files:
+    ```
+    cd i18n && bash compile.sh && cd ..
     ```
 
 5.  Create a branch for local development:


### PR DESCRIPTION
Add instructions to compile i18n, without which test_i18n.py fails on new repository.