### PR TITLE
Optimise image cropping

### DIFF
--- a/robotoff/utils/__init__.py
+++ b/robotoff/utils/__init__.py
@@ -3,7 +3,7 @@ import logging
 import os
 import pathlib
 import sys
-import tempfile
+from io import BytesIO
 from typing import Any, Callable, Dict, Iterable, Optional, Union
 
 import orjson
@@ -128,11 +128,7 @@ def get_image_from_url(
     if r.status_code != 200:
         return None
 
-    with tempfile.NamedTemporaryFile() as f:
-        f.write(r.content)
-        image = Image.open(f.name)
-
-    return image
+    return Image.open(BytesIO(r.content))
 
 
 http_session = requests.Session()

--- a/services/ann/utils.py
+++ b/services/ann/utils.py
@@ -4,7 +4,7 @@ import logging
 import os
 import pathlib
 import sys
-import tempfile
+from io import BytesIO
 from typing import Callable, Dict, Iterable, Optional, Tuple, Union
 
 import requests
@@ -125,8 +125,4 @@ def get_image_from_url(
     if r.status_code != 200:
         return None
 
-    with tempfile.NamedTemporaryFile() as f:
-        f.write(r.content)
-        image = Image.open(f.name)
-
-    return image
+    return Image.open(BytesIO(r.content))


### PR DESCRIPTION
by constructing the Image object directly from the response bytes rather than writing it to a temp file just to read it back into memory.

Not sure if this fixes the root cause of the linked issue. If this doesn't resolve it, at least we would get different errors in Sentry than `cannot identify image file '/tmp/tmpixa936_c'` so it's still a step in the right direction.

