### PR TITLE
Update project-related configuration to lint/check 'services/ann' fil…

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,6 @@
 [flake8]
 ignore = E203, E501, W503
 max-line-length = 88
-application-package-names=robotoff
 exclude = .git,__pycache__,build,dist,*_pb2.py,.venv
 per-file-ignores =
     robotoff/cli/main.py:B008

--- a/.github/workflows/robotoff.yml
+++ b/.github/workflows/robotoff.yml
@@ -73,7 +73,7 @@ jobs:
         run: poetry run isort . --check
 
       - name: Typing check mypy
-        run: poetry run mypy .
+        run: poetry run mypy . services/ann
 
       #----------------------------------------------
       # Compile i18n

--- a/doc/introduction/contributing.md
+++ b/doc/introduction/contributing.md
@@ -85,7 +85,7 @@ development.
     ```
     flake8
     black --check .
-    mypy .
+    mypy . services/ann
     isort --check .
     poetry run pytest tests
     ```


### PR DESCRIPTION
…epath

While working on something I've realised that `flake8` and `mypy` skip over `services/ann` subdir - this PR fixes this.

I didn't find an elegant way to get `mypy` to traverse all of the subdirs without explicitly listing them - but would be happy to learn how it can be done :)