### PR TITLE
Allow to not post anything on Slack if the robotoff is running as dev/locally

### DIFF
--- a/robotoff/logo_label_type.py
+++ b/robotoff/logo_label_type.py
@@ -1,0 +1,4 @@
+from typing import Optional, Tuple
+
+# Extracted into a separate module to avoid circular dependencies.
+LogoLabelType = Tuple[str, Optional[str]]

--- a/robotoff/logos.py
+++ b/robotoff/logos.py
@@ -9,6 +9,7 @@ from robotoff.insights import InsightType
 from robotoff.insights.annotate import InvalidInsight, is_automatically_processable
 from robotoff.insights.dataclass import ProductInsights, RawInsight
 from robotoff.insights.importer import import_insights
+from robotoff.logo_label_type import LogoLabelType
 from robotoff.models import ImageModel, LogoAnnotation, LogoConfidenceThreshold
 from robotoff.slack import NotifierFactory
 from robotoff.utils import get_logger, http_session
@@ -22,8 +23,6 @@ LOGO_TYPE_MAPPING: Dict[str, InsightType] = {
     "label": InsightType.label,
 }
 
-
-LogoLabelType = Tuple[str, Optional[str]]
 UNKNOWN_LABEL: LogoLabelType = ("UNKNOWN", None)
 
 

--- a/robotoff/logos.py
+++ b/robotoff/logos.py
@@ -10,7 +10,7 @@ from robotoff.insights.annotate import InvalidInsight, is_automatically_processa
 from robotoff.insights.dataclass import ProductInsights, RawInsight
 from robotoff.insights.importer import import_insights
 from robotoff.models import ImageModel, LogoAnnotation, LogoConfidenceThreshold
-from robotoff.slack import post_message
+from robotoff.slack import NotifierFactory
 from robotoff.utils import get_logger, http_session
 from robotoff.utils.cache import CachedStore
 
@@ -254,7 +254,7 @@ def import_logo_insights(
     imported = import_insights(product_insights, server_domain, automatic=True)
 
     for logo, probs in zip(selected_logos, logo_probs):
-        send_logo_notification(logo, probs)
+        NotifierFactory.get_notifier().send_logo_notification(logo, probs)
 
     return imported
 
@@ -373,23 +373,3 @@ def generate_raw_insight(
         predictor="universal-logo-detector",
         data=kwargs,
     )
-
-
-def send_logo_notification(logo: LogoAnnotation, probs: Dict[LogoLabelType, float]):
-    crop_url = logo.get_crop_image_url()
-    prob_text = "\n".join(
-        (
-            f"{label[0]} - {label[1]}: {prob:.2g}"
-            for label, prob in sorted(
-                probs.items(), key=operator.itemgetter(1), reverse=True
-            )
-        )
-    )
-    barcode = logo.image_prediction.image.barcode
-    base_off_url = settings.BaseURLProvider().get()
-    text = (
-        f"Prediction for <{crop_url}|image> "
-        f"(<https://hunger.openfoodfacts.org/logos?logo_id={logo.id}|annotate logo>, "
-        f"<{base_off_url}/product/{barcode}|product>):\n{prob_text}"
-    )
-    post_message(text, settings.SLACK_OFF_ROBOTOFF_ALERT_CHANNEL)

--- a/robotoff/settings.py
+++ b/robotoff/settings.py
@@ -126,12 +126,13 @@ _slack_token = os.environ.get("SLACK_TOKEN", "")
 # Returns the slack token to use for posting alerts if the current instance is the 'prod' instance.
 # For all other instances, the empty string is returned.
 def slack_token() -> str:
-    if _robotoff_instance == "prod" and _slack_token is not None:
-        return _slack_token
-    elif _slack_token is None:
-        raise ValueError("No SLACK_TOKEN specified for prod Robotoff")
+    if _robotoff_instance == "prod":
+        if _slack_token != "":
+            return _slack_token
+        else:
+            raise ValueError("No SLACK_TOKEN specified for prod Robotoff")
 
-    if _slack_token is not None:
+    if _slack_token != "":
         raise ValueError("SLACK_TOKEN specified for non-prod Robotoff")
     return ""
 

--- a/robotoff/settings.py
+++ b/robotoff/settings.py
@@ -120,13 +120,21 @@ ELASTICSEARCH_PRODUCT_INDEX_CONFIG_PATH = (
     PROJECT_DIR / "robotoff/elasticsearch/index/product_index.json"
 )
 
-SLACK_TOKEN = os.environ.get("SLACK_TOKEN", "")
-SLACK_OFF_TEST_CHANNEL = "CGLCKGVHS"
-SLACK_OFF_ROBOTOFF_ALERT_CHANNEL = "CGKPALRCG"
-SLACK_OFF_ROBOTOFF_USER_ALERT_CHANNEL = "CGWSXDGSF"
-SLACK_OFF_ROBOTOFF_PRIVATE_IMAGE_ALERT_CHANNEL = "GGMRWLEF2"
-SLACK_OFF_ROBOTOFF_PUBLIC_IMAGE_ALERT_CHANNEL = "CT2N423PA"
-SLACK_OFF_NUTRISCORE_ALERT_CHANNEL = "CJZNFCSNP"
+_slack_token = os.environ.get("SLACK_TOKEN", "")
+
+
+# Returns the slack token to use for posting alerts if the current instance is the 'prod' instance.
+# For all other instances, the empty string is returned.
+def slack_token() -> str:
+    if _robotoff_instance == "prod" and _slack_token is not None:
+        return _slack_token
+    elif _slack_token is None:
+        raise ValueError("No SLACK_TOKEN specified for prod Robotoff")
+
+    if _slack_token is not None:
+        raise ValueError("SLACK_TOKEN specified for non-prod Robotoff")
+    return ""
+
 
 _sentry_dsn = os.environ.get("SENTRY_DSN")
 

--- a/robotoff/slack.py
+++ b/robotoff/slack.py
@@ -1,16 +1,15 @@
+import operator
 from typing import Any, Dict, List, Optional
 
 import requests
-import operator
 
 from robotoff import settings
 from robotoff.insights._enum import InsightType
 from robotoff.insights.dataclass import RawInsight
-from robotoff.models import ProductInsight
+from robotoff.logos import LogoLabelType
+from robotoff.models import LogoAnnotation, ProductInsight
 from robotoff.utils import get_logger, http_session
 from robotoff.utils.types import JSONType
-from robotoff.models import LogoAnnotation
-from robotoff.logos import LogoLabelType
 
 logger = get_logger(__name__)
 

--- a/robotoff/slack.py
+++ b/robotoff/slack.py
@@ -6,7 +6,7 @@ import requests
 from robotoff import settings
 from robotoff.insights._enum import InsightType
 from robotoff.insights.dataclass import RawInsight
-from robotoff.logos import LogoLabelType
+from robotoff.logo_label_type import LogoLabelType
 from robotoff.models import LogoAnnotation, ProductInsight
 from robotoff.utils import get_logger, http_session
 from robotoff.utils.types import JSONType

--- a/robotoff/slack.py
+++ b/robotoff/slack.py
@@ -40,7 +40,7 @@ class NotifierFactory:
     def get_notifier() -> SlackNotifierInterface:
         token = settings.slack_token()
         if token == "":
-            return NoopSlackNotifier()  # TODO How to do private classes?
+            return NoopSlackNotifier()
         return SlackNotifier(token)
 
 

--- a/robotoff/workers/tasks/import_image.py
+++ b/robotoff/workers/tasks/import_image.py
@@ -19,7 +19,7 @@ from robotoff.logos import (
 from robotoff.models import ImageModel, ImagePrediction, LogoAnnotation, db
 from robotoff.off import get_server_type
 from robotoff.products import Product, get_product_store
-from robotoff.slack import notify_image_flag
+from robotoff.slack import NotifierFactory
 from robotoff.utils import get_logger
 from robotoff.workers.client import send_ipc_event
 
@@ -38,7 +38,7 @@ def import_image(barcode: str, image_url: str, ocr_url: str, server_domain: str)
 
     for insight_type, insights in insights_all.items():
         if insight_type == InsightType.image_flag:
-            notify_image_flag(
+            NotifierFactory.get_notifier().notify_image_flag(
                 insights.insights,
                 insights.source_image,  # type: ignore
                 insights.barcode,

--- a/services/ann/settings.py
+++ b/services/ann/settings.py
@@ -30,7 +30,7 @@ if _ann_instance != "prod" and _ann_instance != "dev":
 _sentry_dsn = os.environ.get("SENTRY_DSN")
 
 
-def init_sentry(integrations: Sequence[Integration] = None):
+def init_sentry(integrations: Sequence[Integration] = ()):
     if _sentry_dsn:
         sentry_sdk.init(
             _sentry_dsn,

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1,0 +1,19 @@
+import pytest
+
+from robotoff import settings, slack
+
+
+@pytest.mark.parametrize(
+    "token_value,want_type",
+    [
+        ("T", slack.SlackNotifier),
+        ("", slack.NoopSlackNotifier),
+    ],
+)
+def test_notifier_factory(monkeypatch, token_value, want_type):
+    def test_slack_token(t: str) -> str:
+        return t
+
+    monkeypatch.setattr(settings, "slack_token", lambda: test_slack_token(token_value))
+    notifier = slack.NotifierFactory.get_notifier()
+    assert type(notifier) is want_type


### PR DESCRIPTION
This PR achieves the following:

1. SLACK_TOKEN misconfiguration errors occur closer to init time, which helps to catch these misconfigurations sooner.
2. Slack functionality now uses the [factory design pattern](https://realpython.com/factory-method-python/), which allows to better encapsulate slack-only functionality and allows the caller not to care about checking for the currently running instance.
3. Adds tests for the new code (the old code didn't and still does not have test coverage - we can add it incrementally over time).

This is the last change necessary to allow running non-prod versions of Robotoff.