### PR TITLE
Fix incorrect peewee query

### DIFF
--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -934,6 +934,8 @@ class DumpResource:
         writer = None
 
         with tempfile.TemporaryFile("w+", newline="") as temp_f:
+            logger.info("Dumping insights into temp file.")
+
             for insight in insights_iter:
                 serial = orjson.loads(orjson.dumps(insight.to_dict()))
 
@@ -943,6 +945,7 @@ class DumpResource:
 
                 writer.writerow(serial)
 
+            logger.info("Dump file written - constructing HTTP response.")
             temp_f.seek(0)
             content = temp_f.read()
 

--- a/robotoff/app/core.py
+++ b/robotoff/app/core.py
@@ -21,7 +21,7 @@ def get_insights(
     keep_types: List[str] = None,
     country: str = None,
     brands: List[str] = None,
-    annotated: Optional[bool] = False,
+    annotated: Optional[bool] = None,
     annotation: Optional[int] = None,
     order_by: Optional[str] = None,
     value_tag: Optional[str] = None,
@@ -31,7 +31,7 @@ def get_insights(
     limit: Optional[int] = 25,
     offset: Optional[int] = None,
     count: bool = False,
-    latent: Optional[bool] = False,
+    latent: Optional[bool] = None,
 ) -> Iterable[ProductInsight]:
     if server_domain is None:
         server_domain = settings.OFF_SERVER_DOMAIN


### PR DESCRIPTION
Currently many of the API calls will always append 'where latent=false and annotated=false' to the Postgres query because the defaults for these func params are `False` instead of `None`.

This causes missing data to be returned in the API calls. This PR fixes this