### PR TITLE
Add first tests for importer.py and fix automatic processing bug

### DIFF
--- a/robotoff/insights/dataclass.py
+++ b/robotoff/insights/dataclass.py
@@ -99,7 +99,7 @@ class Insight:
             data=insight.data,
             value_tag=insight.value_tag,
             value=insight.value,
-            automatic_processing=insight.automatic_processing or False,
+            automatic_processing=insight.automatic_processing,
             barcode=product_insights.barcode,
             source_image=product_insights.source_image,
             predictor=insight.predictor,

--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -143,6 +143,8 @@ class BaseInsightImporter(metaclass=abc.ABCMeta):
         return seen_set
 
     def get_seen_count(self, barcode: str, server_domain: str) -> int:
+        """Return the number of non-latent insights that have the same barcode and
+        server domain as provided as parameter."""
         query = generate_seen_set_query(self.get_type(), barcode, server_domain)
         return query.count()
 

--- a/tests/insights/test_importer.py
+++ b/tests/insights/test_importer.py
@@ -1,0 +1,76 @@
+import uuid
+from typing import Any, Dict, List, Optional
+
+from robotoff.insights._enum import InsightType
+from robotoff.insights.dataclass import ProductInsights, RawInsight
+from robotoff.insights.importer import ProductWeightImporter
+
+DEFAULT_BARCODE = "3760094310634"
+DEFAULT_SERVER_DOMAIN = "api.openfoodfacts.org"
+
+
+class FakeProductStore:
+    def __init__(self, data: Optional[Dict] = None):
+        self.data = data or {}
+
+    def is_real_time(self):
+        return False
+
+    def __getitem__(self, item):
+        return self.data.get(item)
+
+
+class TestProductWeightImporter:
+    @staticmethod
+    def generate_raw_insight(value, data: Dict[str, Any]):
+        return RawInsight(
+            type=InsightType.product_weight,
+            data=data,
+            automatic_processing=None,
+            predictor="ocr",
+        )
+
+    @staticmethod
+    def get_product_weight_insights(
+        insights: List[RawInsight],
+        barcode: Optional[str] = None,
+        source_image: Optional[str] = None,
+    ):
+        return ProductInsights(
+            insights=insights,
+            barcode=barcode or DEFAULT_BARCODE,
+            type=InsightType.product_weight,
+            source_image=source_image,
+        )
+
+    def test_import_single_insight(self, mocker):
+        batch_insert_mock = mocker.patch("robotoff.insights.importer.batch_insert")
+        mocker.patch(
+            "robotoff.insights.importer.ProductWeightImporter.get_seen_count",
+            return_value=0,
+        )
+        product_store = FakeProductStore()
+        importer = ProductWeightImporter(product_store)
+        value = "poids net: 30 g"
+        insight_data = {"matcher_type": "with_mention", "value": value}
+        insights = self.get_product_weight_insights(
+            [self.generate_raw_insight(value, insight_data)], DEFAULT_BARCODE
+        )
+        importer.import_insights(
+            [insights], automatic=True, server_domain=DEFAULT_SERVER_DOMAIN
+        )
+        batch_insert_mock.assert_called_once()
+        _, inserted_insights, __ = batch_insert_mock.call_args[0]
+        assert len(inserted_insights) == 1
+        inserted_insight = inserted_insights[0]
+        assert inserted_insight["latent"] is False
+        assert inserted_insight["automatic_processing"] is True
+        assert inserted_insight["barcode"] == DEFAULT_BARCODE
+        assert inserted_insight["type"] == "product_weight"
+        assert inserted_insight["data"] == insight_data
+        assert inserted_insight["value_tag"] is None
+        assert inserted_insight["reserved_barcode"] is False
+        assert inserted_insight["server_domain"] == DEFAULT_SERVER_DOMAIN
+        assert inserted_insight["server_type"] == "off"
+        # check that id is a valid UUID
+        uuid.UUID(inserted_insight["id"])


### PR DESCRIPTION
- Restore automatic processing for `product_weight`, `expiration_date` insight types
- Add very basic tests for product insight import as a starter