### PR TITLE
Temporarily remove OCR ML category detection as it breaks Robotoff

### DIFF
--- a/robotoff/insights/ocr/core.py
+++ b/robotoff/insights/ocr/core.py
@@ -101,10 +101,10 @@ def extract_insights(
     elif insight_type == InsightType.image_lang:
         return get_image_lang(content)
 
-# TODO: This has been temporarily commented-out as this breaks OCR detection
-# due to the model not being fully integrated with Robotoff.
-#     elif insight_type == InsightType.category:
-#         return predict_ocr_categories(content)
+    # TODO: This has been temporarily commented-out as this breaks OCR detection
+    # due to the model not being fully integrated with Robotoff.
+    #     elif insight_type == InsightType.category:
+    #         return predict_ocr_categories(content)
 
     else:
         raise ValueError("unknown insight type: {}".format(insight_type))

--- a/robotoff/insights/ocr/core.py
+++ b/robotoff/insights/ocr/core.py
@@ -101,8 +101,10 @@ def extract_insights(
     elif insight_type == InsightType.image_lang:
         return get_image_lang(content)
 
-    elif insight_type == InsightType.category:
-        return predict_ocr_categories(content)
+# TODO: This has been temporarily commented-out as this breaks OCR detection
+# due to the model not being fully integrated with Robotoff.
+#     elif insight_type == InsightType.category:
+#         return predict_ocr_categories(content)
 
     else:
         raise ValueError("unknown insight type: {}".format(insight_type))


### PR DESCRIPTION
Robotoff breaks in the dev environment as this model has not been fully integrated and is crashing the Robotoff workers. Temporarily removing the code to allow Robotoff to run in dev.