### PR TITLE
feat: add monitoring config w/ gunicorn statsd

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 COMPOSE_PATH_SEPARATOR=;
-COMPOSE_FILE=docker-compose.yml;docker/ml.yml;docker/dev.yml
+COMPOSE_FILE=docker-compose.yml;docker/dev.yml
 
 # Robotoff
 TAG=latest

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -73,7 +73,7 @@ jobs:
           echo "COMPOSE_HTTP_TIMEOUT=200" >> .env
           echo "COMPOSE_PROJECT_NAME=po" >> .env
           echo "COMPOSE_PATH_SEPARATOR=;" >> .env
-          echo "COMPOSE_FILE=docker-compose.yml;docker/prod.yml" >> .env
+          echo "COMPOSE_FILE=docker-compose.yml;docker/prod.yml;docker/monitor.yml" >> .env
           echo "TAG=sha-${{ github.sha }}" >> .env
 
           # Set app variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ COPY poetry.lock pyproject.toml poetry.toml /opt/robotoff/
 
 WORKDIR /opt/robotoff
 ENTRYPOINT /docker-entrypoint.sh $0 $@
-CMD [ "gunicorn", "--config /opt/robotoff/gunicorn.py", "--statsd-host=statsd:9125", "--statsd-prefix=robotoff", "--log-file=-", "robotoff.app.api:api"]
+CMD [ "gunicorn", "--config /opt/robotoff/gunicorn.py", "--log-file=-", "robotoff.app.api:api"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ COPY poetry.lock pyproject.toml poetry.toml /opt/robotoff/
 
 WORKDIR /opt/robotoff
 ENTRYPOINT /docker-entrypoint.sh $0 $@
-CMD [ "gunicorn", "--config /opt/robotoff/gunicorn.py", "robotoff.app.api:api"]
+CMD [ "gunicorn", "--config /opt/robotoff/gunicorn.py", "--statsd-host=statsd:9125", "--statsd-prefix=robotoff", "--log-file=-", "robotoff.app.api:api"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,6 @@ services:
     mem_limit: 2g
     depends_on:
       - workers
-      - statsd
     ports:
       - 5500:5500
     networks:
@@ -104,17 +103,6 @@ services:
     command: postgres -c shared_buffers=1024MB -c work_mem=64MB
     mem_limit: 4g
     shm_size: 1g
-    networks:
-      - webnet
-
-  statsd:
-    image: prom/statsd-exporter
-    volumes:
-      - ./statsd.conf:/statsd/statsd.conf
-    command:
-      - "--statsd.mapping-config=/statsd/statsd.conf"
-    ports:
-      - 9102:9102
     networks:
       - webnet
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     mem_limit: 2g
     depends_on:
       - workers
+      - statsd
     ports:
       - 5500:5500
     networks:
@@ -103,6 +104,17 @@ services:
     command: postgres -c shared_buffers=1024MB -c work_mem=64MB
     mem_limit: 4g
     shm_size: 1g
+    networks:
+      - webnet
+
+  statsd:
+    image: prom/statsd-exporter
+    volumes:
+      - ./statsd.conf:/statsd/statsd.conf
+    command:
+      - "--statsd.mapping-config=/statsd/statsd.conf"
+    ports:
+      - 9102:9102
     networks:
       - webnet
 

--- a/docker/monitor.yml
+++ b/docker/monitor.yml
@@ -1,0 +1,22 @@
+version: "3.9"
+services:
+  api:
+    command:
+      - gunicorn
+      - --config /opt/robotoff/gunicorn.py
+      - --statsd-host=statsd:9125
+      - --statsd-prefix=robotoff
+      - --log-file=-
+      - robotoff.app.api:api
+    depends_on:
+      - statsd
+  statsd:
+    image: prom/statsd-exporter
+    volumes:
+      - ./statsd.conf:/statsd/statsd.conf
+    command:
+      - "--statsd.mapping-config=/statsd/statsd.conf"
+    ports:
+      - 9102:9102
+    networks:
+      - webnet

--- a/statsd.conf
+++ b/statsd.conf
@@ -1,0 +1,26 @@
+mappings:
+- match: ([\w-]+)\.gunicorn\.request\.status\.(\d+)
+  match_type: regex
+  name: "gunicorn_request_status"
+  labels:
+    status: "${2}"
+    app: "${1}"
+    origin: "${1}.gunicorn.request.status.${2}"
+- match: ([\w-]+)\.gunicorn\.request\.duration
+  match_type: regex
+  name: "gunicorn_request_duration"
+  labels:
+    app: "${1}"
+    origin: "${1}.gunicorn.request.duration"
+- match: ([\w-]+)\.gunicorn\.workers
+  match_type: regex
+  name: "gunicorn_workers"
+  labels:
+    app: "${1}"
+    origin: "${1}.gunicorn.workers"
+- match: ([\w-]+)\.gunicorn\.requests
+  match_type: regex
+  name: "gunicorn_requests"
+  labels:
+    app: "${1}"
+    origin: "${1}.gunicorn.requests"


### PR DESCRIPTION
Adds a `statsd-exporter` sidecar container that will collect metrics from `gunicorn`, to be scraped by Prometheus.