### PR TITLE
Fix broken OFF_SERVER_DOMAIN checks

### DIFF
--- a/robotoff/settings.py
+++ b/robotoff/settings.py
@@ -87,7 +87,7 @@ def off_credentials() -> Dict:
     return {"user_id": _off_user, "password": _off_password}
 
 
-OFF_SERVER_DOMAIN = 'api.' + BaseURLProvider().domain
+OFF_SERVER_DOMAIN = "api." + BaseURLProvider().domain
 
 # Taxonomies are huge JSON files that describe many concepts in OFF, in many languages, with synonyms. Those are the full version of taxos.
 


### PR DESCRIPTION
A recent commit forced all of the API calls from OFF to rejected by Robotoff due to a mismatch in the domain format:

OFF sends 'api.openfoodfacts.net' as its domain, while Robotoff expect it to be 'https://api.openfoodfacts.net'.

This commit reverts the settings val to 'api.openfoodfacts.net'.