### PR TITLE
Bump TF Serving Version

### DIFF
--- a/docker/ml.yml
+++ b/docker/ml.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   tf_serving:
     restart: $RESTART_POLICY
-    image: tensorflow/serving:1.15.0
+    image: tensorflow/serving:2.4.0
     ports:
       - 8501:8501
       - 8500:8500


### PR DESCRIPTION
Updating TF Serving to `2.4.0` as the older versions don't support the preprocessing layers in the category classifier.