### PR TITLE
Add the default doc type to ES requests

### DIFF
--- a/robotoff/utils/es.py
+++ b/robotoff/utils/es.py
@@ -36,7 +36,7 @@ def insert_batch(client, batch: Iterable[Tuple[Dict, Dict]], index: str):
     for action, source in batch:
         body += "{}\n{}\n".format(json.dumps(action), json.dumps(source))
 
-    client.bulk(body=body, index=index)
+    client.bulk(body=body, index=index, doc_type="_doc")
 
 
 def generate_msearch_body(index: str, queries: Iterable[Dict]):


### PR DESCRIPTION
Turns out you still need to specify the doctype in ES [insert requests](https://elasticsearch-py.readthedocs.io/en/v7.15.2/api.html#elasticsearch.Elasticsearch.bulk) even if it's the default type.