### PR TITLE
Re-introduce DOCTYPE for Elasticsearch queries

### DIFF
--- a/robotoff/elasticsearch/category/match.py
+++ b/robotoff/elasticsearch/category/match.py
@@ -45,6 +45,7 @@ def match(client, query: str, lang: str):
     body = generate_request(query, lang)
     return client.search(
         index=settings.ElasticsearchIndex.CATEGORY,
+        doc_type=settings.ELASTICSEARCH_TYPE,
         body=body,
         _source=True,
     )

--- a/robotoff/elasticsearch/export.py
+++ b/robotoff/elasticsearch/export.py
@@ -24,6 +24,7 @@ class ElasticsearchExporter:
             body={"query": {"match_all": {}}},
             index=index,
             ignore_unavailable=True,
+            doc_type=settings.ELASTICSEARCH_TYPE,
         )
 
         logger.info(f"Deleted %d documents from {index}", resp["deleted"])

--- a/robotoff/elasticsearch/index/category_index.json
+++ b/robotoff/elasticsearch/index/category_index.json
@@ -133,7 +133,7 @@
     }
   },
   "mappings": {
-    "_doc": {
+    "document": {
       "properties": {
         "fr:name": {
           "type": "text",

--- a/robotoff/elasticsearch/index/product_index.json
+++ b/robotoff/elasticsearch/index/product_index.json
@@ -31,7 +31,7 @@
     }
   },
   "mappings": {
-    "_doc": {
+    "document": {
       "properties": {
         "ingredients_text_fr": {
           "type": "text",

--- a/robotoff/settings.py
+++ b/robotoff/settings.py
@@ -127,6 +127,7 @@ WORKER_COUNT = int(os.environ.get("WORKER_COUNT", 8))
 # Elastic Search is used for simple category prediction and spellchecking.
 
 ELASTICSEARCH_HOSTS = os.environ.get("ELASTICSEARCH_HOSTS", "localhost:9200").split(",")
+ELASTICSEARCH_TYPE = "document"
 
 
 class ElasticsearchIndex:

--- a/robotoff/utils/es.py
+++ b/robotoff/utils/es.py
@@ -36,7 +36,7 @@ def insert_batch(client, batch: Iterable[Tuple[Dict, Dict]], index: str):
     for action, source in batch:
         body += "{}\n{}\n".format(json.dumps(action), json.dumps(source))
 
-    client.bulk(body=body, index=index, doc_type="_doc")
+    client.bulk(body=body, index=index, doc_type=settings.ELASTICSEARCH_TYPE)
 
 
 def generate_msearch_body(index: str, queries: Iterable[Dict]):


### PR DESCRIPTION
In #478 I removed the doc_type parameters as they were supposedly not needed in later ES versions.

However, even with the default `_doc`, we have to provide the document type when making requests.
Since we need to provide it anyway, I've reverted `_doc` to `document` as keeping it as `_doc` would require a prod migration. As we're trying to migrate prod to a new set-up, any additional complexities are better avoided at this point