### PR TITLE
Replace moving of the PO dump from /tmp with copy

### DIFF
--- a/robotoff/products.py
+++ b/robotoff/products.py
@@ -128,10 +128,10 @@ def fetch_dataset(minify: bool = True) -> bool:
             minify_product_dataset(output_path, minify_path)
 
         logger.info("Moving file(s) to dataset directory")
-        shutil.move(str(output_path), settings.JSONL_DATASET_PATH)
+        shutil.copy(str(output_path), settings.JSONL_DATASET_PATH)
 
         if minify:
-            shutil.move(str(minify_path), settings.JSONL_MIN_DATASET_PATH)
+            shutil.copy(str(minify_path), settings.JSONL_MIN_DATASET_PATH)
 
         save_product_dataset_etag(etag)
         logger.info("Dataset fetched")


### PR DESCRIPTION
Based on the slack discussion:

`shutil.move` throws a `Invalid cross-device link:` when moving files from /tmp/ to /opt/robotoff/.. This is most likely a result of shutil.move optimisations.

Instead of moving the file in one step, we can bypass the issue with an explicit `copy` followed by a `remove` operation.
In this case, an explicit `remove` is not necessary as cleanup will happen when we exist the `with ....` branch.