### PR TITLE
fix: straight conditions for category insights

### DIFF
--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -341,6 +341,9 @@ class CategoryImporter(InsightImporter):
         category: str,
         seen_set: Set[str],
     ):
+        if product is None:
+            return False  # product not in store !
+
         product_categories_tags = getattr(product, "categories_tags", [])
 
         # first check whether this is new information

--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -329,7 +329,7 @@ class CategoryImporter(InsightImporter):
             barcode = insight.barcode
             value_tag: str = insight.value_tag  # type: ignore
 
-            if not self.ignore_insight(product, value_tag, seen_set):
+            if self.ignore_insight(product, value_tag, seen_set):
                 continue
 
             yield insight
@@ -342,7 +342,8 @@ class CategoryImporter(InsightImporter):
         seen_set: Set[str],
     ):
         if product is None:
-            return False  # product not in store !
+            logger.debug("Insight for a product which does not exist, ignoring")
+            return True  # product not in store !
 
         product_categories_tags = getattr(product, "categories_tags", [])
 
@@ -352,14 +353,14 @@ class CategoryImporter(InsightImporter):
                 "The product already belongs to this category, "
                 "considering the insight as invalid"
             )
-            return False
+            return True
 
         if category in seen_set:
             logger.debug(
                 "An insight already exists for this product and "
                 "category, considering the insight as invalid"
             )
-            return False
+            return True
 
         # Check that the predicted category is not a parent of a
         # current/already predicted category
@@ -381,9 +382,9 @@ class CategoryImporter(InsightImporter):
                         "category or of the predicted category of an insight, "
                         "considering the insight as invalid"
                     )
-                    return False
+                    return True
 
-        return True
+        return False
 
 
 class ProductWeightImporter(InsightImporter):

--- a/robotoff/prediction/category/neural/category_classifier.py
+++ b/robotoff/prediction/category/neural/category_classifier.py
@@ -55,7 +55,7 @@ class CategoryClassifier:
             setting deepest_only=True will return ['beans'].
         """
 
-        if "ingredients_tags" not in product or "product_name" not in product:
+        if not (product.get("ingredients_tags") and product.get("product_name")):
             return None
 
         data = {

--- a/robotoff/prediction/category/neural/category_classifier.py
+++ b/robotoff/prediction/category/neural/category_classifier.py
@@ -55,8 +55,11 @@ class CategoryClassifier:
             setting deepest_only=True will return ['beans'].
         """
 
-        if not (product.get("ingredients_tags") and product.get("product_name")):
+        # model was train with product having a name
+        if not product.get("product_name"):
             return None
+        # ingredients are not mandatory, just insure correct type
+        product.setdefault("ingredients_tags", [])
 
         data = {
             "signature_name": "serving_default",

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -77,7 +77,10 @@ def test_categorize_no_product(mocker, capsys):
 def test_categorize(mocker, capsys, confidence, want_nothing):
     mocker.patch(
         "robotoff.products.get_product",
-        return_value={"product_name": "Test Product", "ingredients_tags": []},
+        return_value={
+            "product_name": "Test Product",
+            "ingredients_tags": ["ingredient1"],
+        },
     )
     mocker.patch(
         "robotoff.prediction.category.neural.category_classifier.http_session.post",

--- a/tests/unit/prediction/category/neural/test_category_classifier.py
+++ b/tests/unit/prediction/category/neural/test_category_classifier.py
@@ -56,22 +56,41 @@ def test_predict_missing_data():
 @pytest.mark.parametrize(
     "data",
     [
-        {"product_name": "Test Product"},  # missing ingredients_tags
-        {"ingredients_tags": ["ingredient1"]},  # missing product_name
+        # missing ingredients_tags
+        {"product_name": "Test Product"},
+        # ingredients_tag empty
         {
             "ingredients_tags": [],
             "product_name": "Test Product",
-        },  # ingredients_tag empty
-        {"ingredients_tags": ["ingredient1"], "product_name": ""},  # product_name empty
+        },
     ],
     ids=[
         "missing ingredients_tags",
-        "missing product_name",
         "ingredients_tag empty",
+    ],
+)
+def test_predict_ingredients_only(mocker, data):
+    mocker.patch(
+        "robotoff.prediction.category.neural.category_classifier.http_session.post",
+        return_value=_prediction_resp(["en:meat"], [0.99]),
+    )
+    classifier = CategoryClassifier({"en:meat": {"names": "meat"}})
+    predictions = classifier.predict(data)
+    assert predictions == [CategoryPrediction("en:meat", 0.99)]
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"ingredients_tags": ["ingredient1"]},  # missing product_name
+        {"ingredients_tags": ["ingredient1"], "product_name": ""},  # product_name empty
+    ],
+    ids=[
+        "missing product_name",
         "product_name empty",
     ],
 )
-def test_predict_incomplete_products(mocker, data):
+def test_predict_product_no_title(mocker, data):
     mocker.patch(
         "robotoff.prediction.category.neural.category_classifier.http_session.post",
         return_value=_prediction_resp(["en:meat"], [0.99]),

--- a/tests/unit/prediction/category/neural/test_category_classifier.py
+++ b/tests/unit/prediction/category/neural/test_category_classifier.py
@@ -54,6 +54,34 @@ def test_predict_missing_data():
 
 
 @pytest.mark.parametrize(
+    "data",
+    [
+        {"product_name": "Test Product"},  # missing ingredients_tags
+        {"ingredients_tags": ["ingredient1"]},  # missing product_name
+        {
+            "ingredients_tags": [],
+            "product_name": "Test Product",
+        },  # ingredients_tag empty
+        {"ingredients_tags": ["ingredient1"], "product_name": ""},  # product_name empty
+    ],
+    ids=[
+        "missing ingredients_tags",
+        "missing product_name",
+        "ingredients_tag empty",
+        "product_name empty",
+    ],
+)
+def test_predict_incomplete_products(mocker, data):
+    mocker.patch(
+        "robotoff.prediction.category.neural.category_classifier.http_session.post",
+        return_value=_prediction_resp(["en:meat"], [0.99]),
+    )
+    classifier = CategoryClassifier({"en:meat": {"names": "meat"}})
+    predictions = classifier.predict(data)
+    assert predictions is None
+
+
+@pytest.mark.parametrize(
     "deepest_only,mock_response,want_predictions",
     [
         # Nothing predicted - nothing returned.


### PR DESCRIPTION
This is a fix to avoid predicting categories when we should not.

@mithridatea you need to confirm my choice that we should not predict with neural if ingredients is empty (I may be wrong).