### PR TITLE
Make `prediction.automatic_processing` field nullable

### DIFF
--- a/robotoff/elasticsearch/export.py
+++ b/robotoff/elasticsearch/export.py
@@ -40,7 +40,7 @@ class ElasticsearchExporter:
 
     def load_index(self, index: str, index_filepath: Path) -> None:
         """Creates the given index if it doesn't already exist."""
-        if not self.es_client.indices.exists(index):
+        if not self.es_client.indices.exists(index=index):
             logger.info(f"Creating index: {index}")
             with open(index_filepath, "rb") as f:
                 conf = orjson.loads(f.read())

--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -648,7 +648,7 @@ def create_prediction_model(
         "value_tag": prediction.value_tag,
         "value": prediction.value,
         "source_image": product_predictions.source_image,
-        "automatic_processing": prediction.automatic_processing or False,
+        "automatic_processing": prediction.automatic_processing,
         "server_domain": server_domain,
         "predictor": prediction.predictor,
     }

--- a/robotoff/models.py
+++ b/robotoff/models.py
@@ -153,7 +153,7 @@ class Prediction(BaseModel):
     value_tag = peewee.TextField(null=True)
     value = peewee.TextField(null=True)
     source_image = peewee.TextField(null=True, index=True)
-    automatic_processing = peewee.BooleanField(default=False)
+    automatic_processing = peewee.BooleanField(null=True)
     server_domain = peewee.TextField(
         help_text="server domain linked to the insight", index=True
     )


### PR DESCRIPTION
As we further decouple prediction from insight import, we need to keep
track if the prediction automatic_processing is null or not.