### PR TITLE
Ag fix scheduler and tasks transaction - fixes #608

### DIFF
--- a/robotoff/workers/tasks/import_image.py
+++ b/robotoff/workers/tasks/import_image.py
@@ -17,7 +17,7 @@ from robotoff.logos import (
     import_logo_insights,
     save_nearest_neighbors,
 )
-from robotoff.models import ImageModel, ImagePrediction, LogoAnnotation, db
+from robotoff.models import ImageModel, ImagePrediction, LogoAnnotation
 from robotoff.off import get_server_type
 from robotoff.prediction.types import PredictionType
 from robotoff.products import Product, get_product_store
@@ -47,13 +47,12 @@ def import_image(barcode: str, image_url: str, ocr_url: str, server_domain: str)
             )
             continue
 
-    with db.atomic():
-        imported = import_insights(
-            predictions_all.values(),
-            server_domain,
-            automatic=True,
-            product_store=product_store,
-        )
+    imported = import_insights(
+        predictions_all.values(),
+        server_domain,
+        automatic=True,
+        product_store=product_store,
+    )
     logger.info("Import finished, {} insights imported".format(imported))
 
 


### PR DESCRIPTION
I prefer to have a global transaction for each task, as it make code more robust.

We had a problem in preprod, because of a constraint change in table due to #592 which needed a transaction but it was not spotted, and there was some task where no transaction was invoked, resulting in all tasks failing thereafter… see [sentry 2969916843](https://sentry.io/organizations/openfoodfacts/issues/2969916843/?environment=dev&project=1415205&query=is%3Aunresolved)
I think it's safer to put it at a high level.