### PR TITLE
ops: use a specific token for release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,14 +1,17 @@
- on:
-   push:
+  on:
+    push:
       branches:
         - master
- name: release-please
- jobs:
-   release-please:
-     runs-on: ubuntu-latest
-     steps:
-       - uses: GoogleCloudPlatform/release-please-action@v2
-         with:
-           token: ${{ secrets.GITHUB_TOKEN }}
-           release-type: python
-           package-name: robotoff
+  name: release-please
+  jobs:
+    release-please:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: GoogleCloudPlatform/release-please-action@v2
+          with:
+            # We can't use GITHUB_TOKEN here because, github actions can't provocate actions
+            # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+            # So this is a personnal access token
+            token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+            release-type: python
+            package-name: robotoff


### PR DESCRIPTION
because github actions do not trigger actions by default