### PR TITLE
Ag fix vote on delete

### DIFF
--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -18,6 +18,8 @@ x-robotoff-dev: &robotoff-dev
       # make tests available
       - ./tests:/opt/robotoff/tests
       - ./.cov:/opt/robotoff/.cov
+      # make data available
+      - ./data:/opt/robotoff/data
       # make doc generation available
       - ./mkdocs.yml:/opt/robotoff/mkdocs.yml
       - ./build_mkdocs.sh:/opt/robotoff/build_mkdocs.sh

--- a/robotoff/models.py
+++ b/robotoff/models.py
@@ -175,9 +175,11 @@ class Prediction(BaseModel):
 class AnnotationVote(BaseModel):
     id = peewee.UUIDField(primary_key=True, default=uuid.uuid4)
     # The insight this vote belongs to.
-    insight_id = peewee.ForeignKeyField(ProductInsight, null=False, backref="votes")
+    insight_id = peewee.ForeignKeyField(
+        ProductInsight, null=False, backref="votes", on_delete="CASCADE"
+    )
     # The username of the voter - if logged in.
-    # Currently logged in users do not need to vote on an insight for their annotaion to
+    # Currently logged in users do not need to vote on an insight for their annotation to
     # be applied.
     username = peewee.TextField(index=True, null=True)
     # The value of the annotation, see ProductInsight.annotation.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def peewee_db_create():
 
 @pytest.fixture()
 def peewee_db(peewee_db_create):
-    yield
+    yield models.db
     # issue a rollback to cope with cases of failures
     # to avoid reusing same transaction next time
     models.db.rollback()

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -285,7 +285,7 @@ def test_annotate_insight_opposite_votes(client):
 
 # This test checks for handling of cases where we have 3 votes for one annotation,
 # but the follow-up has 2 votes.
-def test_annotate_insight_majority_vote_overriden(client):
+def test_annotate_insight_majority_vote_overridden(client):
     # Add pre-existing insight votes.
     AnnotationVote.create(
         insight_id=insight_id,

--- a/tests/integration/test_models_integration.py
+++ b/tests/integration/test_models_integration.py
@@ -1,0 +1,51 @@
+import pytest
+
+from robotoff import settings
+from robotoff.models import AnnotationVote, ProductInsight
+
+insight_id = "94371643-c2bc-4291-a585-af2cb1a5270a"
+
+
+@pytest.fixture(autouse=True)
+def _set_up_and_tear_down(peewee_db):
+    # clean db
+    AnnotationVote.delete().execute()
+    ProductInsight.delete().execute()
+    # Run the test case.
+    yield
+    # Tear down.
+    AnnotationVote.delete().execute()
+    ProductInsight.delete().execute()
+
+
+def test_vote_cascade_on_insight_deletion(peewee_db):
+    """Test AnnotationVote is cascading on insight deletion"""
+    with peewee_db.atomic():
+        insight = ProductInsight.create(
+            id=insight_id,
+            data="{}",
+            barcode=1,
+            type="category",
+            n_votes=2,
+            value_tag="en:seeds",
+            server_domain=settings.OFF_SERVER_DOMAIN,
+            automatic_processing=False,
+            unique_scans_n=0,
+            reserved_barcode=False,
+        )
+        AnnotationVote.create(
+            insight_id=insight_id,
+            value=1,
+            device_id="device1",
+        )
+        AnnotationVote.create(
+            insight_id=insight_id,
+            value=1,
+            device_id="device2",
+        )
+
+    with peewee_db.atomic():
+        insight.delete().execute()
+
+    assert ProductInsight.select().count() == 0
+    assert AnnotationVote.select().count() == 0


### PR DESCRIPTION
### What

fix: vote should cascade on insight removal fixes #619
    
you must run migration manually:
```
ALTER TABLE annotation_vote DROP  CONSTRAINT annotation_vote_insight_id_fkey;
ALTER TABLE annotation_vote ADD CONSTRAINT annotation_vote_insight_id_fkey FOREIGN KEY (insight_id) REFERENCES product_insight(id) ON DELETE CASCADE;
```

### Fixes bug(s)
- #619 