### PR TITLE
fix(api): Question API, fix query randomness, and allow to use pagination

### DIFF
--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -167,9 +167,7 @@ class InsightCollection:
 class RandomInsightResource:
     def on_get(self, req: falcon.Request, resp: falcon.Response):
         response: JSONType = {}
-        count: int = req.get_param_as_int("count", min_value=1, default=25)
-        page: int = req.get_param_as_int("page", min_value=1, default=1)
-        
+
         insight_type: Optional[str] = req.get_param("type")
         country: Optional[str] = req.get_param("country")
         value_tag: Optional[str] = req.get_param("value_tag")
@@ -181,14 +179,12 @@ class RandomInsightResource:
             get_insights,
             keep_types=keep_types,
             country=country,
-            server_domain=server_domain,
             value_tag=value_tag,
             order_by="random",
             server_domain=server_domain,
         )
 
-        offset: int = (page - 1) * count
-        insights = [i.serialize() for i in get_insights_(limit=count, offset=offset)]
+        insights = [i.serialize() for i in get_insights_(limit=count)]
         response["count"] = get_insights_(count=True)
 
         if not insights:
@@ -199,6 +195,7 @@ class RandomInsightResource:
             response["status"] = "found"
 
         resp.media = response
+
 
 def parse_auth(req: falcon.Request) -> Optional[OFFAuthentication]:
     session_cookie = req.get_cookie_values("session")
@@ -916,7 +913,7 @@ def get_questions_resource_on_get(
     req: falcon.Request, resp: falcon.Response, order_by: str
 ):
     response: JSONType = {}
-    page: int = req.get_param_as_int("page", min_value=1, default=1)       
+    page: int = req.get_param_as_int("page", min_value=1, default=1)
     count: int = req.get_param_as_int("count", min_value=1, default=25)
     lang: str = req.get_param("lang", default="en")
     keep_types: Optional[List[str]] = req.get_param_as_list(

--- a/robotoff/app/core.py
+++ b/robotoff/app/core.py
@@ -107,12 +107,17 @@ def get_insights(
         return query.count()
 
     if limit is not None:
-        query = query.limit(limit).offset(offset)
+        query = query.limit(limit)
+
+    if offset is not None and order_by != "random":
+        query = query.offset(offset)
 
     if order_by is not None:
         if order_by == "random":
             # The +1 is here to avoid 0*rand() = 0
-            query = query.order_by((peewee.fn.Random() * (ProductInsight.n_votes + 1)).desc())
+            query = query.order_by(
+                (peewee.fn.Random() * (ProductInsight.n_votes + 1)).desc()
+            )
 
         elif order_by == "popularity":
             query = query.order_by(ProductInsight.unique_scans_n.desc())

--- a/robotoff/app/core.py
+++ b/robotoff/app/core.py
@@ -111,7 +111,8 @@ def get_insights(
 
     if order_by is not None:
         if order_by == "random":
-            query = query.order_by((peewee.fn.Random() * ProductInsight.n_votes).desc())
+            # The +1 is here to avoid 0*rand() = 0
+            query = query.order_by((peewee.fn.Random() * (ProductInsight.n_votes + 1)).desc())
 
         elif order_by == "popularity":
             query = query.order_by(ProductInsight.unique_scans_n.desc())


### PR DESCRIPTION
### What

This modification is proposed to provide more flexibility in question fetching especially for hunger-game

### Fixes bug(s)
We were relying on the randomness of question requests to populate the batch of questions. But now, you can run multiple time the random query and get the same list of questions
https://robotoff.openfoodfacts.org/api/v1/questions/random?count=10&lang=fr&insight_types=category&value_tag=en:teas

My assumption is that if no product has obtained a vote, `random() * nb_votes` is always 0 and so the order is the "natural" one in the database.

I also reused codes from insight API request to add `page` parameter to the questions route such that event with `popular` soring we are able to fetch all the data


### Part of 

https://github.com/openfoodfacts/openfoodfacts-hungergames/issues/394