### PR TITLE
fix: fix tests date to use utc

### DIFF
--- a/tests/integration/insights/test_process_insights.py
+++ b/tests/integration/insights/test_process_insights.py
@@ -30,7 +30,7 @@ def _create_insight(**kwargs):
             "type": "category",
             "value_tag": "en:Salmons",
             "automatic_processing": True,
-            "process_after": datetime.now() - timedelta(minutes=12),
+            "process_after": datetime.utcnow() - timedelta(minutes=12),
             "n_votes": 3,
         },
         **kwargs,
@@ -45,7 +45,7 @@ def test_process_insight_category(mocker):
     )
     mock = mocker.patch("robotoff.off.update_product")
     # a processed insight exists
-    date0 = datetime.now() - timedelta(minutes=10)
+    date0 = datetime.utcnow() - timedelta(minutes=10)
     id0, code0 = _create_insight(type="category", completed_at=date0, annotation=1)
     # an insight to be processed
     id1, code1 = _create_insight(type="category")
@@ -56,7 +56,7 @@ def test_process_insight_category(mocker):
     # insight 1 processed
     insight = ProductInsight.get(id=id1)
     assert insight.completed_at is not None
-    assert insight.completed_at <= datetime.now()
+    assert insight.completed_at <= datetime.utcnow()
     assert insight.annotation == 1
     # update_product calledfor item 1
     mock.assert_called_once_with(
@@ -83,7 +83,7 @@ def test_process_insight_category_existing(mocker):
     # insight processed
     insight = ProductInsight.get(id=id1)
     assert insight.completed_at is not None
-    assert insight.completed_at <= datetime.now()
+    assert insight.completed_at <= datetime.utcnow()
     assert insight.annotation == 1
     # but update_product wasn't called
     mock.assert_not_called()
@@ -99,7 +99,7 @@ def test_process_insight_non_existing_product(mocker):
     # insight processed
     insight = ProductInsight.get(id=id1)
     assert insight.completed_at is not None
-    assert insight.completed_at <= datetime.now()
+    assert insight.completed_at <= datetime.utcnow()
     assert insight.annotation == 1
     # but update_product wasn't called
     mock.assert_not_called()
@@ -175,7 +175,7 @@ def test_process_insight_same_product(mocker):
     for id_ in [id1, id2, id3]:
         insight = ProductInsight.get(id=id_)
         assert insight.completed_at is not None
-        assert insight.completed_at <= datetime.now()
+        assert insight.completed_at <= datetime.utcnow()
         assert insight.annotation == 1
     # update_product was called twice
     assert mock.call_count == 2

--- a/tests/integration/models_utils.py
+++ b/tests/integration/models_utils.py
@@ -58,7 +58,7 @@ class PredictionFactory(PeeweeModelFactory):
     barcode = factory.Sequence(lambda n: f"{n:013}")
     type = "category"
     data: Dict[str, Any] = {}
-    timestamp = factory.LazyFunction(datetime.now)
+    timestamp = factory.LazyFunction(datetime.utcnow)
     value_tag = "en:seeds"
     server_domain = factory.LazyFunction(lambda: settings.OFF_SERVER_DOMAIN)
 

--- a/tests/integration/test_scheduler.py
+++ b/tests/integration/test_scheduler.py
@@ -17,7 +17,7 @@ def _set_up_and_tear_down(peewee_db):
 
 
 def test_mark_insights():
-    now = datetime.now()
+    now = datetime.utcnow()
     # not automatic
     not_auto = ProductInsightFactory(automatic_processing=False)
     # already marked


### PR DESCRIPTION
We were sometime using `utcnow`  and sometime `now`  which makes tests fails in certain conditions
