### PR TITLE
feat: Get Logo Annotation list 

### DIFF
--- a/robotoff/app/core.py
+++ b/robotoff/app/core.py
@@ -329,3 +329,35 @@ def save_annotation(
         "question_answered", username, device_id, insight.barcode
     )
     return result
+
+
+def get_logo_annotation(
+    barcode: Optional[str] = None,
+    keep_types: List[str] = None,
+    value_tag: Optional[str] = None,
+    limit: Optional[int] = 25,
+    offset: Optional[int] = None,
+    count: bool = False,
+) -> Iterable[LogoAnnotation]:
+
+    query = LogoAnnotation.select()
+
+    where_clauses = []
+
+    if barcode:
+        query = query.join(ImagePrediction).join(ImageModel)
+        where_clauses.append(LogoAnnotation.image_prediction.image.barcode == barcode)
+
+    if value_tag:
+        where_clauses.append(LogoAnnotation.annotation_value_tag == value_tag)
+
+    if keep_types:
+        where_clauses.append(LogoAnnotation.annotation_type.in_(keep_types))
+
+    if where_clauses:
+        query = query.where(*where_clauses)
+
+    if count:
+        return query.count()
+    else:
+        return query.iterator()

--- a/robotoff/app/core.py
+++ b/robotoff/app/core.py
@@ -357,6 +357,12 @@ def get_logo_annotation(
     if where_clauses:
         query = query.where(*where_clauses)
 
+    if limit is not None:
+        query = query.limit(limit)
+
+    if offset is not None:
+        query = query.offset(offset)
+
     if count:
         return query.count()
     else:

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -777,13 +777,8 @@ def test_logo_annotation_collection_pagination(client):
     assert data["count"] == 12
     assert data["status"] == "found"
     assert len(data["annotation"]) == 5
-    assert [q["annotation_value_tag"] for q in data["annotation"]] == [
-        "no lactose-00",
-        "no lactose-01",
-        "no lactose-02",
-        "no lactose-03",
-        "no lactose-04",
-    ]
+    annotation_data = [q["annotation_value_tag"] for q in data["annotation"]]
+    annotations = annotation_data
 
     result = client.simulate_get(
         "/api/v1/annotation/collection?count=5&page=2&types=label"
@@ -793,13 +788,8 @@ def test_logo_annotation_collection_pagination(client):
     assert data["count"] == 12
     assert data["status"] == "found"
     assert len(data["annotation"]) == 5
-    assert [q["annotation_value_tag"] for q in data["annotation"]] == [
-        "no lactose-05",
-        "no lactose-06",
-        "no lactose-07",
-        "no lactose-08",
-        "no lactose-09",
-    ]
+    annotation_data = [q["annotation_value_tag"] for q in data["annotation"]]
+    annotations.extend(annotation_data)
 
     result = client.simulate_get(
         "/api/v1/annotation/collection?count=5&page=3&types=label"
@@ -809,11 +799,8 @@ def test_logo_annotation_collection_pagination(client):
     assert data["count"] == 12
     assert data["status"] == "found"
     assert len(data["annotation"]) == 2
-
-    assert [q["annotation_value_tag"] for q in data["annotation"]] == [
-        "no lactose-10",
-        "no lactose-11",
-    ]
+    annotation_data = [q["annotation_value_tag"] for q in data["annotation"]]
+    annotations.extend(annotation_data)
 
     # test for multiple values in "types"
 
@@ -825,10 +812,23 @@ def test_logo_annotation_collection_pagination(client):
     assert data["count"] == 4
     assert data["status"] == "found"
     assert len(data["annotation"]) == 4
-
     annotation_data = [q["annotation_value_tag"] for q in data["annotation"]]
-    annotation_data.sort()
-    assert annotation_data == [
+    annotations.extend(annotation_data)
+
+    annotations.sort()
+    assert annotations == [
+        "no lactose-00",
+        "no lactose-01",
+        "no lactose-02",
+        "no lactose-03",
+        "no lactose-04",
+        "no lactose-05",
+        "no lactose-06",
+        "no lactose-07",
+        "no lactose-08",
+        "no lactose-09",
+        "no lactose-10",
+        "no lactose-11",
         "sea food-00",
         "sea food-01",
         "truffle cake-00",

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -742,10 +742,41 @@ def test_logo_annotation_collection_pagination(client):
     data = result.json
     assert data["count"] == 12
     assert data["status"] == "found"
+    assert len(data["annotation"]) == 5
     assert [q["annotation_value_tag"] for q in data["annotation"]] == [
         "no lactose-00",
         "no lactose-01",
         "no lactose-02",
         "no lactose-03",
         "no lactose-04",
+    ]
+
+    result = client.simulate_get(
+        "/api/v1/annotation/collection?count=5&page=2&keep_types=label"
+    )
+
+    data = result.json
+    assert data["count"] == 12
+    assert data["status"] == "found"
+    assert len(data["annotation"]) == 5
+    assert [q["annotation_value_tag"] for q in data["annotation"]] == [
+        "no lactose-05",
+        "no lactose-06",
+        "no lactose-07",
+        "no lactose-08",
+        "no lactose-09",
+    ]
+
+    result = client.simulate_get(
+        "/api/v1/annotation/collection?count=5&page=3&keep_types=label"
+    )
+
+    data = result.json
+    assert data["count"] == 12
+    assert data["status"] == "found"
+    assert len(data["annotation"]) == 2
+
+    assert [q["annotation_value_tag"] for q in data["annotation"]] == [
+        "no lactose-10",
+        "no lactose-11",
     ]

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -807,6 +807,8 @@ def test_logo_annotation_collection_pagination(client):
         "no lactose-11",
     ]
 
+    # test for multiple values in "types"
+
     result = client.simulate_get(
         "/api/v1/annotation/collection?count=5&page=1&types=category&types=vegan"
     )
@@ -816,9 +818,11 @@ def test_logo_annotation_collection_pagination(client):
     assert data["status"] == "found"
     assert len(data["annotation"]) == 4
 
-    assert [q["annotation_value_tag"] for q in data["annotation"]] == [
-        "truffle cake-00",
-        "truffle cake-01",
+    annotation_data = [q["annotation_value_tag"] for q in data["annotation"]]
+    annotation_data.sort()
+    assert annotation_data == [
         "sea food-00",
         "sea food-01",
+        "truffle cake-00",
+        "truffle cake-01",
     ]

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -678,19 +678,19 @@ def test_logo_annotation_collection_api(client):
         annotation_type="dairies",
     )
 
-    LogoAnnotationFactory(
+    annotation_789 = LogoAnnotationFactory(
         image_prediction__image__barcode="789",
         annotation_value_tag="creme",
         annotation_type="dairies",
     )
 
-    LogoAnnotationFactory(
+    annotation_306 = LogoAnnotationFactory(
         image_prediction__image__barcode="306",
         annotation_value_tag="yoghurt",
         annotation_type="dairies",
     )
 
-    LogoAnnotationFactory(
+    annotation_604 = LogoAnnotationFactory(
         image_prediction__image__barcode="604",
         annotation_value_tag="meat",
         annotation_type="category",
@@ -736,12 +736,20 @@ def test_logo_annotation_collection_api(client):
     result = client.simulate_get(
         "/api/v1/annotation/collection",
         params={
-            "types": ["category", "diaries"],
+            "types": ["category", "dairies"],
         },
     )
     assert result.status_code == 200
     data = result.json
     assert data["count"] == 4
+    assert data["annotation"][0]["id"] == annotation_295.id
+    assert data["annotation"][0]["image_prediction"]["image"]["barcode"] == "295"
+    assert data["annotation"][1]["id"] == annotation_789.id
+    assert data["annotation"][1]["image_prediction"]["image"]["barcode"] == "789"
+    assert data["annotation"][2]["id"] == annotation_306.id
+    assert data["annotation"][2]["image_prediction"]["image"]["barcode"] == "306"
+    assert data["annotation"][3]["id"] == annotation_604.id
+    assert data["annotation"][3]["image_prediction"]["image"]["barcode"] == "604"
 
 
 def test_logo_annotation_collection_pagination(client):

--- a/tests/integration/test_core_integration.py
+++ b/tests/integration/test_core_integration.py
@@ -1,6 +1,11 @@
 import pytest
 
-from robotoff.app.core import get_image_predictions, get_images, get_predictions
+from robotoff.app.core import (
+    get_image_predictions,
+    get_images,
+    get_logo_annotation,
+    get_predictions,
+)
 
 from .models_utils import (
     ImageModelFactory,
@@ -158,3 +163,72 @@ def test_get_images():
     image_model_items = [item.to_dict() for item in image_model_data]
     assert len(image_model_items) == 1
     assert image_model_items[0]["id"] == image_model2.id
+
+
+def test_get_logo_annotation():
+    annotation_123 = LogoAnnotationFactory(
+        image_prediction__image__barcode="123",
+        annotation_value_tag="etorki",
+        annotation_type="brand",
+    )
+
+    annotation_789 = LogoAnnotationFactory(
+        image_prediction__image__barcode="789",
+        annotation_value_tag="creme",
+        annotation_type="dairies",
+    )
+
+    annotation_295 = LogoAnnotationFactory(
+        image_prediction__image__barcode="295",
+        annotation_value_tag="cheese",
+        annotation_type="dairies",
+    )
+
+    annotation_396 = LogoAnnotationFactory(
+        image_prediction__image__barcode="396",
+        annotation_type="label",
+    )
+
+    LogoAnnotationFactory(
+        image_prediction__image__barcode="306",
+        annotation_value_tag="yoghurt",
+        annotation_type="dairies",
+    )
+
+    # tests for "barcode"
+
+    annotation_data = get_logo_annotation(barcode="123")
+    annotation_data_items = [item.to_dict() for item in annotation_data]
+    assert annotation_data_items[0]["id"] == annotation_123.id
+    assert annotation_data_items[0]["image_prediction"]["image"]["barcode"] == "123"
+    assert annotation_data_items[0]["annotation_type"] == "brand"
+
+    annotation_data = get_logo_annotation(barcode="789")
+    annotation_data_items = [item.to_dict() for item in annotation_data]
+    assert annotation_data_items[0]["id"] == annotation_789.id
+    assert annotation_data_items[0]["image_prediction"]["image"]["barcode"] == "789"
+    assert annotation_data_items[0]["annotation_type"] == "dairies"
+
+    annotation_data = get_logo_annotation(barcode="396")
+    annotation_data_items = [item.to_dict() for item in annotation_data]
+    assert annotation_data_items[0]["id"] == annotation_396.id
+    assert annotation_data_items[0]["image_prediction"]["image"]["barcode"] == "396"
+    assert annotation_data_items[0]["annotation_type"] == "label"
+
+    # test for "keep_types"
+
+    annotation_data = get_logo_annotation(keep_types=["dairies"])
+    annotation_data_items = [item.to_dict() for item in annotation_data]
+    annotation_data_items.sort(key=lambda d: d["id"])
+    assert annotation_data_items[0]["annotation_type"] == "dairies"
+    assert annotation_data_items[1]["annotation_type"] == "dairies"
+    assert annotation_data_items[2]["annotation_type"] == "dairies"
+
+    # tests for "value_tag"
+
+    annotation_data = get_logo_annotation(value_tag="cheese")
+    annotation_data_items = [item.to_dict() for item in annotation_data]
+    assert annotation_data_items[0]["id"] == annotation_295.id
+    assert annotation_data_items[0]["annotation_value_tag"] == "cheese"
+    assert annotation_data_items[0]["image_prediction"]["image"]["barcode"] == "295"
+    assert annotation_data_items[0]["annotation_type"] == "dairies"


### PR DESCRIPTION
### What
This PR does the following [from here](https://github.com/openfoodfacts/robotoff/issues/618#issuecomment-1231879826): 

> Next is LogoAnnotationCollection
>
> It's the same thing, with as previous view but for LogoAnnotation:
filters on:
>
> 
> 
> - barcode
> - type filter (a list of type) keep_types (filter on annotation_type)
> - value_tag (filter on annotation_value_tag)

### Part of 
- #618 