### PR TITLE
feat: Add image moderation service

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -107,6 +107,8 @@ jobs:
           echo "SLACK_TOKEN=${{ secrets.SLACK_TOKEN }}" >> .env
           echo "GUNICORN_NUM_WORKERS=8"
           echo "EVENTS_API_URL=https://event.${{ secrets.ROBOTOFF_DOMAIN }}" >> .env
+          # TODO: remove this url when we have a proper server running for this purpose
+          echo "IMAGE_MODERATION_SERVICE_URL=https://amathjourney.com/api/off-annotation/flag-image"
 
 
     - name: Create Docker volumes

--- a/doc/introduction/notifications.md
+++ b/doc/introduction/notifications.md
@@ -7,4 +7,7 @@ It currently does so in the:
 - #moderation-off-alerts (for problematic images like selfies and nudity)
 - #moderation-off-image-alerts (seems a duplication of the previous one)
 
+It can also sends images to a moderation service[^imagenotifier]
+
 [^slack]: see `robotoff.slack.SlackNotifier`
+[^imagenotifier]: see `robotoff.slack.ImageModerationNotifier`

--- a/robotoff/settings.py
+++ b/robotoff/settings.py
@@ -163,6 +163,11 @@ class ElasticsearchIndex:
     }
 
 
+# image moderation service
+IMAGE_MODERATION_SERVICE_URL: Optional[str] = os.environ.get(
+    "IMAGE_MODERATION_SERVICE_URL", None
+)
+
 # Slack paramaters for notifications about detection
 _slack_token = os.environ.get("SLACK_TOKEN", "")
 

--- a/robotoff/slack.py
+++ b/robotoff/slack.py
@@ -19,11 +19,11 @@ class SlackException(Exception):
     pass
 
 
-class SlackNotifierInterface:
-    """SlackNotifierInterface is an interface for posting Robotoff-related alerts and notifications to the OFF Slack channels."""
+class NotifierInterface:
+    """NotifierInterface is an interface for posting Robotoff-related alerts and notifications to the OFF Slack channels."""
 
     def notify_image_flag(
-        self, predictions: List[Prediction], source: str, barcode: str
+        self, predictions: List[Prediction], source_image: str, barcode: str
     ):
         pass
 
@@ -40,11 +40,21 @@ class NotifierFactory:
     """NotifierFactory is responsible for creating a notifier to post notifications to."""
 
     @staticmethod
-    def get_notifier() -> SlackNotifierInterface:
+    def get_notifier() -> NotifierInterface:
+        notifiers: List[NotifierInterface] = []
         token = settings.slack_token()
         if token == "":
-            return NoopSlackNotifier()
-        return SlackNotifier(token)
+            # use a Noop notifier to get logs for tests and dev
+            notifiers.append(NoopSlackNotifier())
+        else:
+            notifiers.append(SlackNotifier(token))
+        moderation_service_url: Optional[str] = settings.IMAGE_MODERATION_SERVICE_URL
+        if moderation_service_url:
+            notifiers.append(ImageModerationNotifier(moderation_service_url))
+        if len(notifiers) == 1:
+            return notifiers[0]
+        else:
+            return MultiNotifier(notifiers)
 
 
 def _sensitive_image(flag_type: str, flagged_label: str) -> bool:
@@ -96,7 +106,57 @@ def _slack_message_block(
     return [block]
 
 
-class SlackNotifier(SlackNotifierInterface):
+class MultiNotifier(NotifierInterface):
+    """Aggregate multiple notifiers in one instance
+
+    See NotifierInterface for methods documentation
+
+    :param notifiers: the notifiers to dispatch to
+    """
+
+    def __init__(self, notifiers: List[NotifierInterface]):
+        self.notifiers: List[NotifierInterface] = notifiers
+
+    def _dispatch(self, function_name: str, *args, **kwargs):
+        """dispatch call to function_name to all notifiers"""
+        for notifier in self.notifiers:
+            fn = getattr(notifier, function_name)
+            fn(*args, **kwargs)
+
+    def notify_image_flag(
+        self, predictions: List[Prediction], source_image: str, barcode: str
+    ):
+        self._dispatch("notify_image_flag", predictions, source_image, barcode)
+
+    def notify_automatic_processing(self, insight: ProductInsight):
+        self._dispatch("notify_automatic_processing", insight)
+
+    def send_logo_notification(
+        self, logo: LogoAnnotation, probs: Dict[LogoLabelType, float]
+    ):
+        self._dispatch("send_logo_notification", logo, probs)
+
+
+class ImageModerationNotifier(NotifierInterface):
+    """Notifier to dispatch to image moderation server
+
+    :param service_url: base url for image moderation service
+    """
+
+    def __init__(self, service_url):
+        self.service_url = service_url
+
+    def notify_image_flag(
+        self, predictions: List[Prediction], source_image: str, barcode: str
+    ):
+        """Send image to the moderation server so that a human can moderate it"""
+        image_url = settings.OFF_IMAGE_BASE_URL + source_image
+        image_id = int(source_image.rsplit("/", 1)[-1].split(".", 1)[0])
+        params = {"imgid": image_id, "url": image_url}
+        http_session.put(f"{self.service_url}/{barcode}", data=params)
+
+
+class SlackNotifier(NotifierInterface):
     """SlackNotifier implements the real SlackNotifier."""
 
     # Slack channel IDs.

--- a/robotoff/slack.py
+++ b/robotoff/slack.py
@@ -20,7 +20,13 @@ class SlackException(Exception):
 
 
 class NotifierInterface:
-    """NotifierInterface is an interface for posting Robotoff-related alerts and notifications to the OFF Slack channels."""
+    """NotifierInterface is an interface for posting
+    Robotoff-related alerts and notifications
+    to various channels.
+    """
+
+    # Note: we do not use abstract methods,
+    # for a notifier might choose to only implements a few
 
     def notify_image_flag(
         self, predictions: List[Prediction], source_image: str, barcode: str
@@ -165,7 +171,7 @@ class ImageModerationNotifier(NotifierInterface):
 
 
 class SlackNotifier(NotifierInterface):
-    """SlackNotifier implements the real SlackNotifier."""
+    """Notifier to send messages on specific slack channels"""
 
     # Slack channel IDs.
     ROBOTOFF_ALERT_CHANNEL = "CGKPALRCG"

--- a/tests/unit/test_slack.py
+++ b/tests/unit/test_slack.py
@@ -43,23 +43,27 @@ class PartialRequestMatcher:
 
 
 @pytest.mark.parametrize(
-    "token_value,want_type",
-    [("T", slack.SlackNotifier), ("", slack.NoopSlackNotifier)],
+    "token_value, moderation_url, want_type",
+    [
+        ("T", "", slack.SlackNotifier),
+        ("T", "http://test.org/", slack.MultiNotifier),
+        ("", "", slack.NoopSlackNotifier),
+    ],
 )
-def test_notifier_factory(monkeypatch, token_value, want_type):
-    def test_slack_token(t: str) -> str:
-        return t
-
-    monkeypatch.setattr(settings, "slack_token", lambda: test_slack_token(token_value))
+def test_notifier_factory(monkeypatch, token_value, moderation_url, want_type):
+    monkeypatch.setattr(settings, "slack_token", lambda: token_value)
+    monkeypatch.setattr(settings, "IMAGE_MODERATION_SERVICE_URL", moderation_url)
     notifier = slack.NotifierFactory.get_notifier()
     assert type(notifier) is want_type
 
 
-def test_notify_image_flag_no_insights(mocker):
+def test_notify_image_flag_no_prediction(mocker):
     mock = mocker.patch("robotoff.slack.http_session.post")
 
-    notifier = slack.SlackNotifier("")
-    # no insights associated to image
+    notifier = slack.MultiNotifier(
+        [slack.SlackNotifier(""), slack.ImageModerationNotifier("")]
+    )
+    # no predictions associated to image
     notifier.notify_image_flag(
         [],
         "/source_image",
@@ -71,12 +75,18 @@ def test_notify_image_flag_no_insights(mocker):
 
 def test_notify_image_flag_public(mocker, monkeypatch):
     """Test notifying a potentially sensitive public image"""
-    mock = mocker.patch(
+    mock_slack = mocker.patch(
         "robotoff.slack.http_session.post", return_value=MockSlackResponse()
+    )
+    mock_image_moderation = mocker.patch(
+        "robotoff.slack.http_session.put", return_value=MockSlackResponse()
     )
     monkeypatch.delenv("ROBOTOFF_SCHEME", raising=False)  # force defaults to apply
 
-    notifier = slack.SlackNotifier("")
+    slack_notifier = slack.SlackNotifier("")
+    notifier = slack.MultiNotifier(
+        [slack_notifier, slack.ImageModerationNotifier("http://images.org/")]
+    )
 
     notifier.notify_image_flag(
         [
@@ -85,28 +95,38 @@ def test_notify_image_flag_public(mocker, monkeypatch):
                 data={"text": "bad_word", "type": "SENSITIVE", "label": "flagged"},
             )
         ],
-        "/source_image",
+        "/source_image/2.jpg",
         "123",
     )
 
-    mock.assert_called_once_with(
-        notifier.POST_MESSAGE_URL,
+    mock_slack.assert_called_once_with(
+        slack_notifier.POST_MESSAGE_URL,
         data=PartialRequestMatcher(
-            f"type: SENSITIVE\nlabel: *flagged*, match: bad_word\n\n <{settings.OFF_IMAGE_BASE_URL}/source_image|Image> -- <https://world.{settings._robotoff_domain}/cgi/product.pl?type=edit&code=123|*Edit*>",
-            notifier.ROBOTOFF_PUBLIC_IMAGE_ALERT_CHANNEL,
-            f"{settings.OFF_IMAGE_BASE_URL}/source_image",
+            f"type: SENSITIVE\nlabel: *flagged*, match: bad_word\n\n <{settings.OFF_IMAGE_BASE_URL}/source_image/2.jpg|Image> -- <https://world.{settings._robotoff_domain}/cgi/product.pl?type=edit&code=123|*Edit*>",
+            slack_notifier.ROBOTOFF_PUBLIC_IMAGE_ALERT_CHANNEL,
+            f"{settings.OFF_IMAGE_BASE_URL}/source_image/2.jpg",
         ),
+    )
+    mock_image_moderation.assert_called_once_with(
+        "http://images.org/123",
+        data={"imgid": 2, "url": f"{settings.OFF_IMAGE_BASE_URL}/source_image/2.jpg"},
     )
 
 
 def test_notify_image_flag_private(mocker, monkeypatch):
     """Test notifying a potentially sensitive private image"""
-    mock = mocker.patch(
+    mock_slack = mocker.patch(
         "robotoff.slack.http_session.post", return_value=MockSlackResponse()
+    )
+    mock_image_moderation = mocker.patch(
+        "robotoff.slack.http_session.put", return_value=MockSlackResponse()
     )
     monkeypatch.delenv("ROBOTOFF_SCHEME", raising=False)  # force defaults to apply
 
-    notifier = slack.SlackNotifier("")
+    slack_notifier = slack.SlackNotifier("")
+    notifier = slack.MultiNotifier(
+        [slack_notifier, slack.ImageModerationNotifier("http://images.org/")]
+    )
 
     notifier.notify_image_flag(
         [
@@ -115,17 +135,21 @@ def test_notify_image_flag_private(mocker, monkeypatch):
                 data={"type": "label_annotation", "label": "face", "likelihood": 0.8},
             )
         ],
-        "/source_image",
+        "/source_image/2.jpg",
         "123",
     )
 
-    mock.assert_called_once_with(
-        notifier.POST_MESSAGE_URL,
+    mock_slack.assert_called_once_with(
+        slack_notifier.POST_MESSAGE_URL,
         data=PartialRequestMatcher(
-            f"type: label_annotation\nlabel: *face*, score: 0.8\n\n <{settings.OFF_IMAGE_BASE_URL}/source_image|Image> -- <https://world.{settings._robotoff_domain}/cgi/product.pl?type=edit&code=123|*Edit*>",
-            notifier.ROBOTOFF_PRIVATE_IMAGE_ALERT_CHANNEL,
-            f"{settings.OFF_IMAGE_BASE_URL}/source_image",
+            f"type: label_annotation\nlabel: *face*, score: 0.8\n\n <{settings.OFF_IMAGE_BASE_URL}/source_image/2.jpg|Image> -- <https://world.{settings._robotoff_domain}/cgi/product.pl?type=edit&code=123|*Edit*>",
+            slack_notifier.ROBOTOFF_PRIVATE_IMAGE_ALERT_CHANNEL,
+            f"{settings.OFF_IMAGE_BASE_URL}/source_image/2.jpg",
         ),
+    )
+    mock_image_moderation.assert_called_once_with(
+        "http://images.org/123",
+        data={"imgid": 2, "url": f"{settings.OFF_IMAGE_BASE_URL}/source_image/2.jpg"},
     )
 
 


### PR DESCRIPTION
Send flagged images to an external moderation database.

Replaces #862