### PR TITLE
refactor: robustness and localdev

### DIFF
--- a/.env
+++ b/.env
@@ -18,7 +18,7 @@ ROBOTOFF_DOMAIN=openfoodfacts.localhost
 
 # for dev we change static to .net
 STATIC_OFF_DOMAIN=https://openfoodfacts.net
-# if you want to connect to a producopener dev instance on localhost, use:
+# if you want to connect to a Product Opener dev instance on localhost, use:
 # STATIC_OFF_DOMAIN=http://openfoodfacts.localhost
 # for dev scheme is http
 ROBOTOFF_SCHEME=http

--- a/.env
+++ b/.env
@@ -15,8 +15,11 @@ PO_LOCAL_NET=po_default
 TAG=latest
 ROBOTOFF_INSTANCE=localhost
 ROBOTOFF_DOMAIN=openfoodfacts.localhost
+
 # for dev we change static to .net
 STATIC_OFF_DOMAIN=https://openfoodfacts.net
+# if you want to connect to a producopener dev instance on localhost, use:
+# STATIC_OFF_DOMAIN=http://openfoodfacts.localhost
 # for dev scheme is http
 ROBOTOFF_SCHEME=http
 # for dev only on localhost
@@ -54,6 +57,6 @@ SENTRY_DSN=
 
 # Workers
 IPC_AUTHKEY=ipc
-IPC_HOST=0.0.0.0
+IPC_HOST=workers
 IPC_PORT=6650
 WORKER_COUNT=8

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -44,6 +44,9 @@ services:
       po_local:
         aliases:
         # trick: make robotoff available outside and inside with same name
+        # with this alias, we can call it from inside docker with same name as outside
+        # and Product Opener will call it from a browser (outside)
+        # or from within perl code (inside)
         - robotoff.openfoodfacts.localhost
         - api
       webnet:

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -31,16 +31,22 @@ x-robotoff-dev: &robotoff-dev
       - ./gh_pages:/opt/robotoff/gh_pages
 
 x-networks-productopener-local: &networks-productopener-local
-    # in dev we want to be able to communicatet with product opener
+    # in dev we want to be able to communicate with product opener
     # using our docker-compose environment
     networks:
-      - po_local
-      - webnet
+      po_local:
+      webnet:
 
 services:
   api:
     <<: *robotoff-dev
-    <<: *networks-productopener-local
+    networks:
+      po_local:
+        aliases:
+        # trick: make robotoff available outside and inside with same name
+        - robotoff.openfoodfacts.localhost
+        - api
+      webnet:
   workers:
     <<: *robotoff-dev
     <<: *networks-productopener-local

--- a/robotoff/off.py
+++ b/robotoff/off.py
@@ -125,6 +125,7 @@ def get_api_product_url(server: Union[ServerType, str]) -> str:
 def get_base_url(server: Union[ServerType, str]) -> str:
     if isinstance(server, str):
         server = server.replace("api", "world")
+        # get scheme, https on prod, but http in dev
         scheme = settings.BaseURLProvider().scheme
         return f"{scheme}://{server}"
     else:

--- a/robotoff/off.py
+++ b/robotoff/off.py
@@ -125,7 +125,8 @@ def get_api_product_url(server: Union[ServerType, str]) -> str:
 def get_base_url(server: Union[ServerType, str]) -> str:
     if isinstance(server, str):
         server = server.replace("api", "world")
-        return "https://{}".format(server)
+        scheme = settings.BaseURLProvider().scheme
+        return f"{scheme}://{server}"
     else:
         if server not in API_URLS:
             raise ValueError("unsupported server type: {}".format(server))

--- a/robotoff/scheduler/__init__.py
+++ b/robotoff/scheduler/__init__.py
@@ -209,7 +209,7 @@ def _update_data():
         # (main Open Food Facts backend)
         # it it called after the download product dataset call.
         _refresh_elasticsearch()
-    except requests.exceptions.ConnectionError:
+    except requests.exceptions.RequestException:
         logger.exception("Exception while running ES updates for categories")
 
 

--- a/robotoff/scheduler/__init__.py
+++ b/robotoff/scheduler/__init__.py
@@ -205,7 +205,8 @@ def _update_data():
     """Refreshes the PO product dump and updates the Elasticsearch index data."""
     try:
         _download_product_dataset()
-        # Elasticsearch is dependent on the availability of the PO product dump, i.e.
+        # Elasticsearch is dependent on the availability of the product dump from Product Opener 
+        # (main Open Food Facts backend) 
         # it it called after the download product dataset call.
         _refresh_elasticsearch()
     except requests.exceptions.ConnectionError:

--- a/robotoff/scheduler/__init__.py
+++ b/robotoff/scheduler/__init__.py
@@ -4,6 +4,7 @@ import os
 import uuid
 from typing import Dict, Iterable
 
+import requests.exceptions
 from apscheduler.events import EVENT_JOB_ERROR
 from apscheduler.executors.pool import ThreadPoolExecutor
 from apscheduler.jobstores.memory import MemoryJobStore
@@ -202,11 +203,13 @@ def _refresh_elasticsearch():
 # this job does no use database
 def _update_data():
     """Refreshes the PO product dump and updates the Elasticsearch index data."""
-
-    _download_product_dataset()
-    # Elasticsearch is dependent on the availability of the PO product dump, i.e.
-    # it it called after the download product dataset call.
-    _refresh_elasticsearch()
+    try:
+        _download_product_dataset()
+        # Elasticsearch is dependent on the availability of the PO product dump, i.e.
+        # it it called after the download product dataset call.
+        _refresh_elasticsearch()
+    except requests.exceptions.ConnectionError:
+        logger.exception("Exception while running ES updates for categories")
 
 
 def generate_insights():

--- a/robotoff/scheduler/__init__.py
+++ b/robotoff/scheduler/__init__.py
@@ -205,8 +205,8 @@ def _update_data():
     """Refreshes the PO product dump and updates the Elasticsearch index data."""
     try:
         _download_product_dataset()
-        # Elasticsearch is dependent on the availability of the product dump from Product Opener 
-        # (main Open Food Facts backend) 
+        # Elasticsearch is dependent on the availability of the product dump from Product Opener
+        # (main Open Food Facts backend)
         # it it called after the download product dataset call.
         _refresh_elasticsearch()
     except requests.exceptions.ConnectionError:

--- a/robotoff/settings.py
+++ b/robotoff/settings.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import logging
 import os
@@ -39,23 +40,29 @@ class BaseURLProvider(object):
         self.prefix = "world"
         self.scheme = os.environ.get("ROBOTOFF_SCHEME", "https")
 
+    def clone(self):
+        return copy.deepcopy(self)
+
     def robotoff(self):
-        self.prefix = "robotoff"
-        return self
+        result = self.clone()
+        result.prefix = "robotoff"
+        return result
 
     def static(self):
-        self.prefix = "static"
+        result = self.clone()
+        result.prefix = "static"
         # locally we may want to change it, give environment a chance
         static_domain = os.environ.get("STATIC_OFF_DOMAIN", "")
         if static_domain:
             if "://" in static_domain:
-                self.scheme, static_domain = static_domain.split("://", 1)
-            self.domain = static_domain
-        return self
+                result.scheme, static_domain = static_domain.split("://", 1)
+            result.domain = static_domain
+        return result
 
     def country(self, country_code: str):
-        self.prefix = country_code
-        return self
+        result = self.clone()
+        result.prefix = country_code
+        return result
 
     def get(self):
         return self.url % {


### PR DESCRIPTION
### What

- make some part of the code and settings more compliant to a use with a local deploy of product opener
- settings had a dangerous pattern in the object to get domains, fixed it.
- also made scheduler more resilient to not having network 

Note: a more serious refactor of networks between docker should be done, but later...

This was done to be able to test https://github.com/openfoodfacts/openfoodfacts-server/pull/7379