### PR TITLE
fix: store category neural model in ProductInsight.predictor field

### DIFF
--- a/robotoff/elasticsearch/category/predict.py
+++ b/robotoff/elasticsearch/category/predict.py
@@ -52,9 +52,9 @@ def predict(client, product: Dict) -> Optional[Prediction]:
             data={
                 "lang": lang,
                 "product_name": product_name,
-                "model": "matcher",
             },
             automatic_processing=False,
+            predictor="matcher",
         )
 
     return None

--- a/robotoff/prediction/category/neural/category_classifier.py
+++ b/robotoff/prediction/category/neural/category_classifier.py
@@ -21,8 +21,9 @@ class CategoryPrediction:
         return Prediction(
             type=PredictionType.category,
             value_tag=self.category,
-            data={"lang": "xx", "model": "neural", "confidence": self.confidence},
+            data={"lang": "xx", "confidence": self.confidence},
             automatic_processing=self.confidence >= self.NEURAL_CONFIDENCE_THRESHOLD,
+            predictor="neural",
         )
 
     def __eq__(self, other):

--- a/tests/integration/insights/test_category_import.py
+++ b/tests/integration/insights/test_category_import.py
@@ -42,9 +42,9 @@ def matcher_prediction(category):
         data={
             "lang": "en",
             "product_name": "test",
-            "model": "matcher",
         },
         automatic_processing=False,
+        predictor="matcher",
     )
 
 
@@ -53,8 +53,9 @@ def neural_prediction(category, confidence=0.7, auto=False):
         barcode=barcode1,
         type=PredictionType.category,
         value_tag=category,
-        data={"lang": "xx", "model": "neural", "confidence": confidence},
+        data={"lang": "xx", "confidence": confidence},
         automatic_processing=auto,
+        predictor="neural",
     )
 
 

--- a/tests/unit/prediction/category/neural/test_category_classifier.py
+++ b/tests/unit/prediction/category/neural/test_category_classifier.py
@@ -17,8 +17,9 @@ def test_category_prediction_to_prediction():
     assert category_prediction.to_prediction() == Prediction(
         type=InsightType.category,
         value_tag="category",
-        data={"lang": "xx", "model": "neural", "confidence": 0.5},
+        data={"lang": "xx", "confidence": 0.5},
         automatic_processing=False,
+        predictor="neural",
     )
 
 
@@ -29,8 +30,9 @@ def test_category_prediction_to_prediction_auto(monkeypatch):
     assert category_prediction.to_prediction() == Prediction(
         type=InsightType.category,
         value_tag="category",
-        data={"lang": "xx", "model": "neural", "confidence": 0.9},
+        data={"lang": "xx", "confidence": 0.9},
         automatic_processing=True,
+        predictor="neural",
     )
 
 

--- a/tests/unit/workers/tasks/test_product_updated.py
+++ b/tests/unit/workers/tasks/test_product_updated.py
@@ -31,8 +31,9 @@ def test_add_category_insight_with_ml_insights(mocker):
         barcode="123",
         type=PredictionType.category,
         value_tag="en:chicken",
-        data={"lang": "xx", "model": "neural", "confidence": 0.9},
+        data={"lang": "xx", "confidence": 0.9},
         automatic_processing=True,
+        predictor="neural",
     )
     mocker.patch(
         "robotoff.workers.tasks.product_updated.predict_category_from_product_es",
@@ -55,8 +56,9 @@ def test_add_category_insight_with_ml_insights(mocker):
                 barcode="123",
                 type=PredictionType.category,
                 value_tag="en:chicken",
-                data={"lang": "xx", "model": "neural", "confidence": 0.9},
+                data={"lang": "xx", "confidence": 0.9},
                 automatic_processing=True,
+                predictor="neural",
             )
         ],
         server_domain,


### PR DESCRIPTION
data->model is a deprecated field, all predictor version/type must be stored in the predictor field
