### PR TITLE
fix: move docker mongodb service to a distinct file in dev mode

### DIFF
--- a/doc/how-to-guides/deployment/dev-install.md
+++ b/doc/how-to-guides/deployment/dev-install.md
@@ -9,6 +9,7 @@ customize parameters by editing the `.env` file.
 You should, consider those changes:
 
 - if you want to use tensorflow models, add `docker/ml.yml` to `COMPOSE_FILE`
+- if you don't work on Product Opener, you should launch MongoDB by adding `docker/mongodb.yml` to `COMPOSE_FILE`
 - change `OFF_UID` and `OFF_GID` to match your own user UID/GID.
   (see [Getting developper uid for docker](https://gist.github.com/alexgarel/6e6158ee869d6db2192e0441fd58576e))
 

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -47,11 +47,6 @@ services:
   scheduler:
     <<: *networks-productopener-local
     <<: *robotoff-dev
-  mongodb:
-    image: mongo:4.4
-    command: mongod --wiredTigerCacheSizeGB 1.5
-    ports:
-      - "127.0.0.1:${MONGO_EXPOSE_PORT:-27017}:27017"
 
 networks:
   # this links to the product opener dev environment on local machine

--- a/docker/mongodb.yml
+++ b/docker/mongodb.yml
@@ -6,3 +6,8 @@ services:
     command: mongod --wiredTigerCacheSizeGB 1.5
     ports:
       - "127.0.0.1:${MONGO_EXPOSE_PORT:-27017}:27017"
+    volumes:
+      - mongodb_data:/data/db
+      
+volumes:
+  mongodb_data:

--- a/docker/mongodb.yml
+++ b/docker/mongodb.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+
+services:
+  mongodb:
+    image: mongo:4.4
+    command: mongod --wiredTigerCacheSizeGB 1.5
+    ports:
+      - "127.0.0.1:${MONGO_EXPOSE_PORT:-27017}:27017"


### PR DESCRIPTION
To avoid conflicts with Product Opener docker mongo instance in dev mode