### PR TITLE
fix: replace with fr prefix references to en:ab-agriculture-biologique

### DIFF
--- a/data/ocr/label_logo_annotation.txt
+++ b/data/ocr/label_logo_annotation.txt
@@ -1,5 +1,5 @@
 igp||en:pgi
-label ab||en:ab-agriculture-biologique
+label ab||fr:ab-agriculture-biologique
 label rouge vectoriel||en:label-rouge
 label rouge||en:label-rouge
 produit en bretagne||en:produced-in-bretagne

--- a/data/ocr/label_whitelist.txt
+++ b/data/ocr/label_whitelist.txt
@@ -95,7 +95,7 @@ en:no-lactose
 en:palm-oil-free
 en:max-havelaar
 en:organic
-en:ab-agriculture-biologique
+fr:ab-agriculture-biologique
 en:no-flavors
 en:no-artificial-flavors
 en:vegan

--- a/robotoff/insights/question.py
+++ b/robotoff/insights/question.py
@@ -21,7 +21,7 @@ LABEL_IMG_BASE_URL = "https://{}/images/lang".format(
 
 LABEL_IMAGES = {
     "en:eu-organic": LABEL_IMG_BASE_URL + "/en/labels/eu-organic.135x90.svg",
-    "en:ab-agriculture-biologique": LABEL_IMG_BASE_URL
+    "fr:ab-agriculture-biologique": LABEL_IMG_BASE_URL
     + "/fr/labels/ab-agriculture-biologique.74x90.svg",
     "en:european-vegetarian-union": LABEL_IMG_BASE_URL
     + "/en/labels/european-vegetarian-union.90x90.svg",

--- a/robotoff/prediction/ocr/label.py
+++ b/robotoff/prediction/ocr/label.py
@@ -64,7 +64,7 @@ LABELS_REGEX = {
             processing_func=process_es_bio_label_code,
         ),
     ],
-    "en:ab-agriculture-biologique": [
+    "fr:ab-agriculture-biologique": [
         OCRRegex(
             re.compile(r"certifi[ée] ab[\s.,)]"),
             field=OCRField.full_text_contiguous,

--- a/tests/integration/models_utils.py
+++ b/tests/integration/models_utils.py
@@ -116,7 +116,7 @@ class LogoAnnotationFactory(PeeweeModelFactory):
     score = 0.7
     annotation_value = "ab agriculture biologique"
     annotation_value_tag = "ab-agriculture-biologique"
-    taxonomy_value = "en:ab-agriculture-biologique"
+    taxonomy_value = "fr:ab-agriculture-biologique"
     annotation_type = "label"
     nearest_neighbors = {"logo_ids": [111111, 222222], "distances": [11.1, 12.4]}
 

--- a/tests/unit/prediction/ocr/test_label.py
+++ b/tests/unit/prediction/ocr/test_label.py
@@ -29,7 +29,7 @@ def test_es_ocr_regex(input_str: str, is_match: bool, output: Optional[str]):
 @pytest.mark.parametrize(
     "text,value_tags",
     [
-        ("certifié ab.", ["en:ab-agriculture-biologique"]),
+        ("certifié ab.", ["fr:ab-agriculture-biologique"]),
         ("décret du 5/01/07", ["en:label-rouge"]),
         ("DECRET du 05.01.07", ["en:label-rouge"]),
         ("Homologation n° LA 21/88", ["en:label-rouge"]),


### PR DESCRIPTION
fr:ab-agriculture-biologique is the correct version
A DB fix in preprod and production is necessary too.
Fixes #450 