### PR TITLE
doc: fix edit link on mkdocs docs

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     # on pull request we just want to build to see nothing is broken
     paths:
+    - "README.md"
     - "doc/**"
     - ".github/workflows/generate-doc.yml"
     - "mkdocs.yml"

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -4,6 +4,12 @@
 
 name: Generate documentation
 on:
+  pull_request:
+    # on pull request we just want to build to see nothing is broken
+    paths:
+    - "doc/**"
+    - ".github/workflows/generate-doc.yml"
+    - "mkdocs.yml"
   push:
     branches:
       - master
@@ -38,9 +44,12 @@ jobs:
       - name: Generate documentation
         run: bash ./build_mkdocs.sh
 
-    # Deploy docs to gh_pages
-    # Example from https://github.com/marketplace/actions/deploy-to-github-pages
+      # Deploy docs to gh_pages if we are pushing to master
+      # Example from https://github.com/marketplace/actions/deploy-to-github-pages
       - name: Deploy 🚀
+        # we only deploy on push to master
+        if: |
+          github.event_name == 'push' && github.event.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@v4.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ docs_dir: doc
 
 # Link to Github on every page
 repo_url: https://github.com/openfoodfacts/robotoff
+edit_uri: blob/main/doc/
 
 site_name: Robotoff
 site_dir: gh_pages


### PR DESCRIPTION
Default link is wrong, see https://openfoodfacts.github.io/robotoff/ (pen on right top corner).

I did configure it on openfoodfacts-server, so I knew how to fix :-)

Also run the documentation build (without publishing) when we touch the doc to avoid breaking it by inadvertence.