### PR TITLE
fix: Stopping tests when one already failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ integration-tests:
 	@echo "🥫 Running integration tests …"
 	# run tests in worker to have more memory
 	# also, change project name to run in isolation
-	${DOCKER_COMPOSE_TEST} run --rm workers poetry run pytest -vv --cov-report xml --cov=robotoff --cov-append tests/integration
+	${DOCKER_COMPOSE_TEST} run --rm workers poetry run pytest -x -vv --cov-report xml --cov=robotoff --cov-append tests/integration
 	( ${DOCKER_COMPOSE_TEST} down -v || true )
 
 # interactive testings


### PR DESCRIPTION
### What
- Adding the -x parameter to the run pytest command for integration test in the Makefile. 

### Why
- When running integration tests, we'd like to stop the tests if one is failing in order to prevent a too large amount of errors from being displayed.
