### PR TITLE
fix: temporarily disable USDA packager code extraction

### DIFF
--- a/robotoff/prediction/ocr/packager_code.py
+++ b/robotoff/prediction/ocr/packager_code.py
@@ -125,22 +125,23 @@ PACKAGER_CODE = {
             lowercase=False,
         ),
     ],
-    "USDA": [
-        # To match the USDA like "EST. 522"
-        OCRRegex(
-            re.compile(r"EST\.*\s*\d{1,5}[A-Z]{0,3}\.*"),
-            field=OCRField.full_text_contiguous,
-            lowercase=False,
-            processing_func=process_USDA_match_to_flashtext,
-        ),
-        # To match the USDA like "V34626"
-        OCRRegex(
-            re.compile(r"[A-Z]\d{1,5}[A-Z]?"),
-            field=OCRField.full_text_contiguous,
-            lowercase=False,
-            processing_func=process_USDA_match_to_flashtext,
-        ),
-    ],
+    # Temporarily disable USDA extraction until the overmatching bug is fixed
+    # "USDA": [
+    #     # To match the USDA like "EST. 522"
+    #     OCRRegex(
+    #         re.compile(r"EST\.*\s*\d{1,5}[A-Z]{0,3}\.*"),
+    #         field=OCRField.full_text_contiguous,
+    #         lowercase=False,
+    #         processing_func=process_USDA_match_to_flashtext,
+    #     ),
+    #     # To match the USDA like "V34626"
+    #     OCRRegex(
+    #         re.compile(r"[A-Z]\d{1,5}[A-Z]?"),
+    #         field=OCRField.full_text_contiguous,
+    #         lowercase=False,
+    #         processing_func=process_USDA_match_to_flashtext,
+    #     ),
+    # ],
 }
 
 

--- a/tests/unit/prediction/ocr/test_packager_code.py
+++ b/tests/unit/prediction/ocr/test_packager_code.py
@@ -15,9 +15,9 @@ from robotoff.prediction.ocr.packager_code import find_packager_codes
         ("FR-AB0-123", []),
         ("fr-098-123", []),
         ("Gluten code is FR-234-234 ", ["FR-234-234"]),
-        ("EST  \n 31778", ["EST. 31778"]),
-        ("EST  \n 9999", []),
-        ("M31779+  P31779+  \tV31779", ["M31779", "P31779", "V31779"]),
+        # ("EST  \n 31778", ["EST. 31778"]),
+        # ("EST  \n 9999", []),
+        # ("M31779+  P31779+  \tV31779", ["M31779", "P31779", "V31779"]),
     ],
 )
 def test_find_packager_codes(text: str, values: List[str]):


### PR DESCRIPTION
There are many false positives during USDA packager code extraction currently, we disable the extraction until the issue is fixed.