### PR TITLE
feat: Improve predict category endpoint

### DIFF
--- a/doc/references/api.yml
+++ b/doc/references/api.yml
@@ -395,6 +395,95 @@ paths:
                   - logos
                   - count
 
+  /predict/category:
+    get:
+      tags:
+        - Predict
+      summary: Predict categories for a product
+      description: |
+        Currently only the neural categorizer is available on this endpoint.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - type: object
+                  properties:
+                    barcode:
+                      type: string
+                      description: The barcode of the product to categorize
+                      minLength: 1
+                      example: 0748162621021
+                    deepest_only:
+                      type: boolean
+                      description: |
+                        If true, only return the deepest elements in the category taxonomy
+                        (don't return categories that are parents of other predicted categories)
+                    threshold:
+                      type: number
+                      description: |
+                        The score above which we consider the category to be detected
+                      default: 0.5
+                  required:
+                    - barcode
+                - type: object
+                  properties:
+                    product:
+                      type: object
+                      properties:
+                        product_name:
+                          type: string
+                          minLength: 1
+                          example: Frozen dinner yeast rolls
+                        ingredients_tags:
+                          type: array
+                          items:
+                            type: string
+                          example:
+                            - "en:fortified-wheat-flour"
+                            - "en:cereal"
+                            - "en:flour"
+                      required:
+                        - product_name
+                    deepest_only:
+                      type: boolean
+                      description: |
+                        If true, only return the deepest elements in the category taxonomy
+                        (don't return categories that are parents of other predicted categories)
+                    threshold:
+                      type: number
+                      description: |
+                        The score above which we consider the category to be detected
+                      default: 0.5
+                  required:
+                    - product
+      responses:
+        "200":
+          description: the category predictions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  neural:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        value_tag:
+                          type: string
+                          description: The predicted `value_tag`
+                          example: en:breads
+                        confidence:
+                          type: number
+                          description: The confidence score of the model
+                          example: 0.6
+                      required:
+                        - value_tag
+                        - confidence
+                required:
+                  - neural
+
 components:
   schemas:
     InsightSearchResult:

--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -402,8 +402,10 @@ class OCRInsightsPredictorResource:
 
 class CategoryPredictorResource:
     def on_get(self, req: falcon.Request, resp: falcon.Response):
-        barcode = req.get_param("barcode", required=True)
-        deepest_only = req.get_param_as_bool("deepest_only", default=False)
+        """Predict categories using neural categorizer for a specific product."""
+        barcode: str = req.get_param("barcode", required=True)
+        deepest_only: bool = req.get_param_as_bool("deepest_only", default=False)
+        threshold: Optional[float] = req.get_param_as_float("threshold", default=None)
 
         categories = []
 
@@ -411,7 +413,7 @@ class CategoryPredictorResource:
         if product:
             predictions = CategoryClassifier(
                 get_taxonomy(TaxonomyType.category.name)
-            ).predict(product, deepest_only)
+            ).predict(product, deepest_only, threshold)
             categories = [p.to_dict() for p in predictions]
 
         resp.media = {"categories": categories}

--- a/robotoff/app/schema.py
+++ b/robotoff/app/schema.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict
+from robotoff.utils.types import JSONType
 
-IMAGE_PREDICTION_IMPORTER_SCHEMA: Dict[str, Any] = {
+IMAGE_PREDICTION_IMPORTER_SCHEMA: JSONType = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Image Prediction Importer",
     "type": "object",
@@ -30,7 +30,7 @@ IMAGE_PREDICTION_IMPORTER_SCHEMA: Dict[str, Any] = {
     "required": ["predictions"],
 }
 
-UPDATE_LOGO_SCHEMA: Dict[str, Any] = {
+UPDATE_LOGO_SCHEMA: JSONType = {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Update Logo",
     "type": "object",
@@ -39,4 +39,49 @@ UPDATE_LOGO_SCHEMA: Dict[str, Any] = {
         "type": {"type": "string", "minLength": 1},
     },
     "required": ["value", "type"],
+}
+
+PREDICT_CATEGORY_SCHEMA: JSONType = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Predict Category",
+    "anyOf": [
+        {
+            "type": "object",
+            "properties": {
+                "barcode": {
+                    "type": "string",
+                    "minLength": 1,
+                },
+                "deepest_only": {
+                    "type": "boolean",
+                },
+                "threshold": {"type": "number"},
+            },
+            "required": ["barcode"],
+        },
+        {
+            "type": "object",
+            "properties": {
+                "product": {
+                    "type": "object",
+                    "properties": {
+                        "product_name": {
+                            "type": "string",
+                            "minLength": 1,
+                        },
+                        "ingredients_tags": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                    },
+                    "required": ["product_name"],
+                },
+                "deepest_only": {
+                    "type": "boolean",
+                },
+                "threshold": {"type": "number"},
+            },
+            "required": ["product"],
+        },
+    ],
 }

--- a/robotoff/prediction/category/neural/category_classifier.py
+++ b/robotoff/prediction/category/neural/category_classifier.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from robotoff import settings
 from robotoff.prediction.types import Prediction, PredictionType
@@ -44,15 +44,28 @@ class CategoryClassifier:
     def __init__(self, category_taxonomy: Taxonomy):
         self.taxonomy = category_taxonomy
 
-    def predict(self, product: Dict, deepest_only: bool = False) -> List[Prediction]:
-        """Returns an unordered list of category predictions for the given product.
+    def predict(
+        self,
+        product: Dict,
+        deepest_only: bool = False,
+        threshold: Optional[float] = None,
+    ) -> List[Prediction]:
+        """Returns an unordered list of category predictions for the given
+        product.
 
-        :param deepest_only: controls whether the returned list should only contain the deepmost categories
-            for a predicted taxonomy chain.
+        :param product: the product to predict the categories from, should
+        have at least `product_name` and `ingredients_tags` fields
+        :param deepest_only: controls whether the returned list should only
+        contain the deepmost categories for a predicted taxonomy chain.
 
-            For example, if we predict 'fresh vegetables' -> 'legumes' -> 'beans' for a product,
+            For example, if we predict 'fresh vegetables' -> 'legumes' ->
+            'beans' for a product,
             setting deepest_only=True will return ['beans'].
+        :param threshold: the score above which we consider the category to be
+        detected (default: 0.5)
         """
+        if threshold is None:
+            threshold = 0.5
 
         # model was train with product having a name
         if not product.get("product_name"):
@@ -95,9 +108,9 @@ class CategoryClassifier:
 
         category_predictions = []
 
-        # We only consider predictions with a confidence score of 0.5 and above.
+        # We only consider predictions with a confidence score of `threshold` and above.
         for idx, confidence in enumerate(prediction["output_mapper_layer"]):
-            if confidence >= 0.5:
+            if confidence >= threshold:
                 category_predictions.append(
                     CategoryPrediction(
                         category=prediction["output_mapper_layer_1"][idx],


### PR DESCRIPTION
- feat: add a `threshold` parameter to /predict/category endpoint
- feat: Improve /predict/category endpoint (allow to provide model input instead of only fetching the product from
DB)
- doc: document /predict/category endpoint on OpenAPI