### PR TITLE
fix: improve /images/logos endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Robotoff works together with [Product Opener](https://github.com/openfoodfacts/o
 
 **Open Food Facts:** <https://world.openfoodfacts.org>
 
+A rendered view of the latest version of the API documentation is available [here](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/openfoodfacts/robotoff/master/doc/references/api.yml).
+
 ## Overview
 
 - To get a better understanding on how Robotoff works, go to [Architecture](https://openfoodfacts.github.io/robotoff/introduction/architecture/).

--- a/doc/references/api.yml
+++ b/doc/references/api.yml
@@ -315,21 +315,45 @@ paths:
           headers: {}
           content:
             image/jpeg: {}
+
   /images/logos:
     get:
       tags:
-        - Images
-      summary: Search or fetch logo annotations
-      description: |
-        If `logo_ids` parameter is provided, return logo annotation about requested logos.
-        Otherwise search logos with the specific filter provided. `logo_ids` and the
-        remaining parameters are mutually exclusive.
+        - Logos
+      summary: Fetch logos
+      description: Return details about requested logos
       parameters:
         - name: logo_ids
-          description: Comma-separated string of logo IDs. Mutually exclusive with the other parameters.
+          description: Comma-separated string of logo IDs
           in: query
           schema:
             type: string
+      responses:
+        "200":
+          description: The fetch results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  logos:
+                    type: array
+                    description: Details about requested logos
+                  count:
+                    type: number
+                    description: Number of returned results
+                required:
+                  - logos
+                  - count
+  /images/logos/search:
+    get:
+      tags:
+        - Logos
+      summary: Search for logos
+      description: |
+        Search for logos detected using the universal-logo-detector model that 
+        meet some criteria (annotation status, annotated, type,...)
+      parameters:
         - name: count
           description: Number of results to return
           in: query
@@ -372,14 +396,15 @@ paths:
           schema:
             type: string
         - name: annotated
-          description: If true, only return annotated logos, otherwise only return non-annotated ones.
+          description: The annotation status of the logo.
+            If not provided, both annotated and non-annotated logos are returned
           in: query
           schema:
             type: boolean
-            default: false
+            default: null
       responses:
         "200":
-          description: "The search/fetch results"
+          description: The search results
           content:
             application/json:
               schema:
@@ -387,7 +412,7 @@ paths:
                 properties:
                   logos:
                     type: array
-                    description: Found logo annotations
+                    description: Found logos
                   count:
                     type: number
                     description: Number of returned results

--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -650,7 +650,11 @@ class ImageLogoSearchResource:
         min_confidence: Optional[float] = req.get_param_as_float("min_confidence")
         random: bool = req.get_param_as_bool("random", default=False)
         server_domain: Optional[str] = req.get_param("server_domain")
-        annotated: bool = req.get_param_as_bool("annotated", default=False)
+        annotated: Optional[bool] = req.get_param_as_bool("annotated")
+
+        where_clauses = []
+        if annotated is not None:
+            where_clauses.append(LogoAnnotation.annotation_value.is_null(not annotated))
 
         where_clauses = [LogoAnnotation.annotation_value.is_null(not annotated)]
         join_image_prediction = False


### PR DESCRIPTION
- fix: create new /images/logos/search endpoint from /images/logos
- fix: allow to fetch both annotated/not annotated logos in /images/logos/search
- doc: add link to rendered view of API documentation in README.md

Required for https://github.com/openfoodfacts/hunger-games/issues/262