### PR TITLE
fix: fix insight import mecanism

### DIFF
--- a/robotoff/cli/main.py
+++ b/robotoff/cli/main.py
@@ -17,10 +17,11 @@ def run(service: str) -> None:
 
 
 @app.command()
-def generate_import_insights(
+def regenerate_ocr_insights(
     barcode: str = typer.Argument(..., help="Barcode of the product")
 ) -> None:
-    """Generate OCR predictions/insights for a specific product and import them."""
+    """Regenerate OCR predictions/insights for a specific product and import
+    them."""
     from robotoff import settings
     from robotoff.insights.extraction import (
         DEFAULT_OCR_PREDICTION_TYPES,

--- a/robotoff/cli/main.py
+++ b/robotoff/cli/main.py
@@ -21,15 +21,15 @@ def generate_import_insights(
     barcode: str = typer.Argument(..., help="Barcode of the product")
 ) -> None:
     """Generate OCR predictions/insights for a specific product and import them."""
+    from robotoff import settings
     from robotoff.insights.extraction import (
         DEFAULT_OCR_PREDICTION_TYPES,
         extract_ocr_predictions,
     )
     from robotoff.insights.importer import import_insights as import_insights_
     from robotoff.off import generate_json_ocr_url
-    from robotoff.utils import get_logger
-    from robotoff import settings
     from robotoff.products import get_product
+    from robotoff.utils import get_logger
 
     logger = get_logger()
 
@@ -296,11 +296,9 @@ def refresh_insights(
     refreshed, otherwise insights of all products are refreshed.
     """
     from robotoff import settings
+    from robotoff.insights.importer import refresh_all_insights
+    from robotoff.insights.importer import refresh_insights as refresh_insights_
     from robotoff.utils import get_logger
-    from robotoff.insights.importer import (
-        refresh_insights as refresh_insights_,
-        refresh_all_insights,
-    )
 
     logger = get_logger()
     server_domain = server_domain or settings.OFF_SERVER_DOMAIN

--- a/robotoff/cli/main.py
+++ b/robotoff/cli/main.py
@@ -268,6 +268,41 @@ def apply_insights(
 
 
 @app.command()
+def refresh_insights(
+    barcode: Optional[str] = typer.Option(
+        None,
+        help="Refresh a specific product. If not provided, all products are updated",
+    ),
+    server_domain: Optional[str] = typer.Option(
+        None, help="The server domain to use, Open Food Facts by default"
+    ),
+):
+    """Refresh insights based on available predictions.
+
+    If a `barcode` is provided, only the insights of this product is
+    refreshed, otherwise insights of all products are refreshed.
+    """
+    from robotoff import settings
+    from robotoff.utils import get_logger
+    from robotoff.insights.importer import (
+        refresh_insights as refresh_insights_,
+        refresh_all_insights,
+    )
+
+    logger = get_logger()
+    server_domain = server_domain or settings.OFF_SERVER_DOMAIN
+
+    if barcode is not None:
+        logger.info(f"Refreshing product {barcode}")
+        imported = refresh_insights_(barcode, server_domain, automatic=True)
+    else:
+        logger.info("Refreshing insights of all products")
+        imported = refresh_all_insights(server_domain, automatic=True)
+
+    logger.info(f"Refreshed insights: {imported}")
+
+
+@app.command()
 def init_elasticsearch(
     load_index: bool = False,
     load_data: bool = True,

--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -343,8 +343,9 @@ class InsightImporter(metaclass=abc.ABCMeta):
             for candidate in candidates:
                 if candidate.automatic_processing is None:
                     logger.warning(
-                        "Insight with automatic_processing=None: %s", candidate.__data__
+                        "Insight with automatic_processing=None", candidate.__data__
                     )
+                    candidate.automatic_processing = False
 
                 if not is_trustworthy_insight_image(
                     product.images, candidate.source_image

--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -183,14 +183,15 @@ def sort_predictions(predictions: Iterable[Prediction]) -> List[Prediction]:
 
 def sort_candidates(candidates: Iterable[ProductInsight]) -> List[ProductInsight]:
     """Sort candidates by priority, using as keys:
+
     - priority, specified by data["priority"], candidate with lowest priority
-    values (high priority) come first
+      values (high priority) come first
     - source image upload datetime (most recent first): images IDs are
-    auto-incremented integers, so the most recent images have the highest IDs.
-    Images with `source_image = None` have a lower priority that images with a
-    source image.
+      auto-incremented integers, so the most recent images have the highest IDs.
+      Images with `source_image = None` have a lower priority that images with a
+      source image.
     - automatic processing status: candidates that are automatically
-    processable have higher priority
+      processable have higher priority
 
     This function should be used to make sure most important candidates are
     looked into first in `get_insight_update`. Note that the sorting keys are
@@ -343,7 +344,7 @@ class InsightImporter(metaclass=abc.ABCMeta):
             for candidate in candidates:
                 if candidate.automatic_processing is None:
                     logger.warning(
-                        "Insight with automatic_processing=None", candidate.__data__
+                        "Insight with automatic_processing=None: %s", candidate.__data__
                     )
                     candidate.automatic_processing = False
 
@@ -409,16 +410,13 @@ class InsightImporter(metaclass=abc.ABCMeta):
             if reference.annotation is not None
         )
         for candidate in sort_candidates(candidates):
-            match = False
-            for reference in (
-                reference_insight
+            # if match is True, candidate conflicts with existing insight,
+            # keeping existing insight and discarding candidate
+            match = any(
+                cls.is_conflicting_insight(candidate, reference_insight)
                 for reference_insight in reference_insights
                 if reference_insight.annotation is not None
-            ):
-                if cls.is_conflicting_insight(candidate, reference):
-                    # Candidate conflicts with existing insight, keeping
-                    # existing insight and discarding candidate
-                    match = True
+            )
 
             if not match:
                 for selected in to_create:

--- a/robotoff/models.py
+++ b/robotoff/models.py
@@ -83,7 +83,7 @@ class ProductInsight(BaseModel):
     # Contains some additional data based on the type of the insight from above.
     # NOTE: there is no 1:1 mapping between the type and the JSON format provided here, for example for
     # type==label, the data here could be: {"logo_id":X,"confidence":Y}, or {"text":X,"notify":Y}
-    data = BinaryJSONField(index=True)
+    data = BinaryJSONField(index=True, default=dict)
 
     # Timestamp is the timestamp of when this insight was imported into the DB.
     timestamp = peewee.DateTimeField(null=True, index=True)

--- a/robotoff/prediction/ocr/category.py
+++ b/robotoff/prediction/ocr/category.py
@@ -110,6 +110,7 @@ def find_category(content: Union[OCRResult, str]) -> List[Prediction]:
                         value_tag=category_value,
                         predictor="regex",
                         data={"text": match.group(), "notify": ocr_regex.notify},
+                        automatic_processing=False,
                     )
                 )
     return predictions

--- a/robotoff/products.py
+++ b/robotoff/products.py
@@ -22,6 +22,12 @@ logger = get_logger(__name__)
 
 
 def get_image_id(image_path: str) -> Optional[str]:
+    """Return the image ID from an image path.
+
+    :param image_path: the image path (ex: /322/247/762/7888/2.jpg)
+    :return: the image ID ("2" in the previous example) or None if the image
+    is not "raw" (not digit-numbered)
+    """
     image_id = pathlib.Path(image_path).stem
 
     if image_id.isdigit():

--- a/tests/integration/insights/test_category_import.py
+++ b/tests/integration/insights/test_category_import.py
@@ -21,12 +21,15 @@ def _set_up_and_tear_down(peewee_db):
         barcode=barcode1,
         type="category",
         value_tag="en:salmons",
+        automatic_processing=False,
+        predictor="matcher",
     )
     ProductInsightFactory(
         id=insight_id1,
         barcode=barcode1,
         type="category",
         value_tag="en:salmons",
+        predictor="matcher",
     )
     # Run the test case.
     yield
@@ -66,7 +69,7 @@ class TestCategoryImporter:
     """
 
     def fake_product_store(self):
-        return {barcode1: Product({"categories_tags": ["en:Fish"]})}
+        return {barcode1: Product({"categories_tags": ["en:fish"]})}
 
     def _run_import(self, predictions, product_store=None):
         if product_store is None:
@@ -82,28 +85,30 @@ class TestCategoryImporter:
     @pytest.mark.parametrize(
         "predictions",
         [
-            # empty list
-            [],
             # category already on product
-            [matcher_prediction("en:Fish")],
-            [neural_prediction("en:Fish")],
+            [matcher_prediction("en:fish")],
+            [neural_prediction("en:fish")],
             # category already in insights
             [matcher_prediction("en:salmons")],
             [neural_prediction("en:salmons")],
             # both
             [
-                matcher_prediction("en:Fish"),
+                matcher_prediction("en:fish"),
                 matcher_prediction("en:salmons"),
-                neural_prediction("en:Fish"),
+                neural_prediction("en:fish"),
                 neural_prediction("en:salmons"),
             ],
         ],
     )
-    def test_import_nothing(self, predictions):
+    def test_import_one_same_value_tag(self, predictions):
+        """Test when there is a single import, but the value_tag stays the
+        same."""
         imported = self._run_import(predictions)
-        assert imported == 0
+        assert imported == 1
         # no insight created
         assert ProductInsight.select().count() == 1
+        insight = ProductInsight().select().limit(1)[0]
+        assert insight.value_tag == "en:salmons"
 
     @pytest.mark.parametrize(
         "predictions",
@@ -119,7 +124,9 @@ class TestCategoryImporter:
             ],
         ],
     )
-    def test_import_one(self, predictions):
+    def test_import_one_different_value_tag(self, predictions):
+        """Test when a more precise category is available as prediction: the
+        prediction should be used as insight instead of the less precise one."""
         imported = self._run_import(predictions)
         assert imported == 1
         # no insight created

--- a/tests/integration/models_utils.py
+++ b/tests/integration/models_utils.py
@@ -50,6 +50,7 @@ class ProductInsightFactory(UuidSequencer, PeeweeModelFactory):
     server_type = "off"
     unique_scans_n = 10
     annotation = None
+    automatic_processing = False
 
 
 class PredictionFactory(PeeweeModelFactory):
@@ -62,6 +63,8 @@ class PredictionFactory(PeeweeModelFactory):
     timestamp = factory.LazyFunction(datetime.utcnow)
     value_tag = "en:seeds"
     server_domain = factory.LazyFunction(lambda: settings.OFF_SERVER_DOMAIN)
+    automatic_processing = None
+    predictor = None
 
 
 class AnnotationVoteFactory(UuidSequencer, PeeweeModelFactory):


### PR DESCRIPTION
The main addition of this PR is a fix of the insight import mecanism.

Currently, when a prediction based on a more recent image is available, we don't transform this prediction into an insight, we keep the old insight.
This is problematic as the insight based on the newer image may make it automatically processable (if the image is selected or if it's not too old compared to most recent images). As knowing which insight to keep/delete and which candidate to import is tricky (many subtle bugs were discovered since the introduction of this feature), I chose here a more radical approach: we regenerate all insights for a product from predictions and only keep annotated insights in DB.

I also added a better sorting of candidates:
- we now set a higher priority on candidates that are automatically processable (this field may be set after the ProductInsight creation, that's why we cannot sort according to this field in `sort_predictions`)
- we now set a higher priority on candidates that have a non null predictor field