### PR TITLE
fix: add small fixes

### DIFF
--- a/data/ocr/brand_taxonomy_blacklist.txt
+++ b/data/ocr/brand_taxonomy_blacklist.txt
@@ -12,6 +12,7 @@ american
 appel
 artisanal
 aucune
+asia
 // 'auchan' is the brand to use
 auchan production
 avenue
@@ -28,6 +29,7 @@ crisp
 cristal
 crunch
 cucina
+delice
 delta
 deluxe
 demeter
@@ -46,11 +48,13 @@ frigo
 fromage
 fruite
 geant
+gold
 golden
 gourmet
 granola
 grenade
 gusto
+homemade
 ice-tea
 ideal
 italia
@@ -100,7 +104,11 @@ the-coca-cola-company
 thomas
 tradition
 tropical
+tous les jours
 valor
 vegan
 veritas
 ice tea
+// wrigley's is the correct brand
+wrigley
+wal-mart-stores

--- a/doc/references/api.yml
+++ b/doc/references/api.yml
@@ -185,6 +185,8 @@ paths:
         - $ref: "#/components/parameters/insight_type"
         - $ref: "#/components/parameters/country"
         - $ref: "#/components/parameters/value_tag"
+        - $ref: "#/components/parameters/server_domain"
+        - $ref: "#/components/parameters/count"
         - $ref: "#/components/parameters/predictor"
       responses:
         "200":

--- a/doc/references/api.yml
+++ b/doc/references/api.yml
@@ -62,6 +62,7 @@ paths:
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/reserved_barcode"
         - $ref: "#/components/parameters/campaign"
+        - $ref: "#/components/parameters/predictor"
       responses:
         "200":
           description: The queried insights
@@ -102,6 +103,7 @@ paths:
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/reserved_barcode"
         - $ref: "#/components/parameters/campaign"
+        - $ref: "#/components/parameters/predictor"
       responses:
         "200":
           description: ""
@@ -129,6 +131,7 @@ paths:
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/reserved_barcode"
         - $ref: "#/components/parameters/campaign"
+        - $ref: "#/components/parameters/predictor"
       responses:
         "200":
           description: "The number of questions grouped by `value_tag`"
@@ -182,6 +185,7 @@ paths:
         - $ref: "#/components/parameters/insight_type"
         - $ref: "#/components/parameters/country"
         - $ref: "#/components/parameters/value_tag"
+        - $ref: "#/components/parameters/predictor"
       responses:
         "200":
           description: ""
@@ -702,11 +706,19 @@ components:
     campaign:
       name: campaign
       in: query
-      description: Filter by annotation campaign.
+      description: Filter by annotation campaign
         An annotation campaign allows to only retrieve questions about selected products, based on arbitrary criteria
       schema:
         type: string
         example: agribalyse-category
+    predictor:
+      name: predictor
+      in: query
+      description: Filter by predictor value
+        A predictor refers to the model/method that was used to generate the prediction.
+      schema:
+        type: string
+        example: universal-logo-detector
     barcode_path:
       name: barcode
       in: path

--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -98,8 +98,8 @@ class ProductInsightResource:
         server_domain: Optional[str] = req.get_param("server_domain")
         response: JSONType = {}
         insights = [
-            i.serialize()
-            for i in get_insights(
+            insight.to_dict()
+            for insight in get_insights(
                 barcode=barcode, server_domain=server_domain, limit=None
             )
         ]
@@ -197,7 +197,7 @@ class RandomInsightResource:
             predictor=predictor,
         )
 
-        insights = [i.serialize() for i in get_insights_(limit=count)]
+        insights = [insight.to_dict() for insight in get_insights_(limit=count)]
         response["count"] = get_insights_(count=True)
 
         if not insights:

--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -256,16 +256,14 @@ class AnnotateInsightResource:
         # This field is only needed for nutritional table structure insights.
         data = req.get_param_as_json("data")
 
-        auth: Optional[OFFAuthentication] = parse_auth(req)
-        trusted_annotator: bool = auth is not None
+        auth = parse_auth(req)
+        trusted_annotator = auth is not None
 
         device_id = device_id_from_request(req)
-
-        username = auth.get_username() if auth else "unknown annotator"
         logger.info(
-            "New annotation received from {} (annotation: {}, insight: {})".format(
-                username, annotation, insight_id
-            )
+            "New annotation received from "
+            f"{auth.get_username() if auth else 'unknown annotator'} "
+            f"(annotation: {annotation}, insight: {insight_id})"
         )
 
         annotation_result = save_annotation(

--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -683,18 +683,15 @@ class ImageLogoSearchResource:
         if annotated is not None:
             where_clauses.append(LogoAnnotation.annotation_value.is_null(not annotated))
 
+        if min_confidence is not None:
+            where_clauses.append(LogoAnnotation.score >= min_confidence)
+
         join_image_prediction = False
         join_image_model = False
 
         if server_domain:
             where_clauses.append(ImageModel.server_domain == server_domain)
             join_image_model = True
-
-        if min_confidence is not None:
-            # TODO(raphael): We should filter based on individual logo object confidence
-            # and not on image object with the maximum confidence
-            where_clauses.append(ImagePrediction.max_confidence >= min_confidence)
-            join_image_prediction = True
 
         if barcode is not None:
             where_clauses.append(ImageModel.barcode == barcode)

--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -137,6 +137,7 @@ class InsightCollection:
         annotation: Optional[int] = req.get_param_as_int("annotation")
         value_tag: str = req.get_param("value_tag")
         brands = req.get_param_as_list("brands") or None
+        predictor = req.get_param("predictor")
         server_domain: Optional[str] = req.get_param("server_domain")
 
         if keep_types:
@@ -157,6 +158,7 @@ class InsightCollection:
             annotated=annotated,
             annotation=annotation,
             barcode=barcode,
+            predictor=predictor,
         )
 
         offset: int = (page - 1) * count
@@ -182,6 +184,7 @@ class RandomInsightResource:
         value_tag: Optional[str] = req.get_param("value_tag")
         server_domain: Optional[str] = req.get_param("server_domain")
         count: int = req.get_param_as_int("count", default=1, min_value=1, max_value=50)
+        predictor = req.get_param("predictor")
 
         keep_types = [insight_type] if insight_type else None
         get_insights_ = functools.partial(
@@ -191,6 +194,7 @@ class RandomInsightResource:
             value_tag=value_tag,
             order_by="random",
             server_domain=server_domain,
+            predictor=predictor,
         )
 
         insights = [i.serialize() for i in get_insights_(limit=count)]
@@ -991,6 +995,7 @@ def get_questions_resource_on_get(
     )
     # filter by annotation campaign
     campaign: Optional[str] = req.get_param("campaign")
+    predictor = req.get_param("predictor")
 
     # If the device_id is not provided as a request parameter, we use the
     # hash of the IPs as a backup.
@@ -1024,6 +1029,7 @@ def get_questions_resource_on_get(
         avoid_voted_on=_get_skip_voted_on(auth, device_id),
         automatically_processable=False,
         campaign=campaign,
+        predictor=predictor,
     )
 
     offset: int = (page - 1) * count
@@ -1214,6 +1220,7 @@ class UnansweredQuestionCollection:
             "reserved_barcode", default=False
         )
         campaign: Optional[str] = req.get_param("campaign")
+        predictor = req.get_param("predictor")
 
         get_insights_ = functools.partial(
             get_insights,
@@ -1225,6 +1232,7 @@ class UnansweredQuestionCollection:
             automatically_processable=False,
             reserved_barcode=reserved_barcode,
             campaign=campaign,
+            predictor=predictor,
         )
 
         offset: int = (page - 1) * count

--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -183,7 +183,7 @@ class RandomInsightResource:
         country: Optional[str] = req.get_param("country")
         value_tag: Optional[str] = req.get_param("value_tag")
         server_domain: Optional[str] = req.get_param("server_domain")
-        count: int = req.get_param_as_int("count", default=1, min_value=1, max_value=50)
+        count: int = req.get_param_as_int("count", min_value=1, default=25)
         predictor = req.get_param("predictor")
 
         keep_types = [insight_type] if insight_type else None
@@ -918,14 +918,14 @@ class WebhookProductResource:
 
 
 class ProductQuestionsResource:
-    """Get a question about a product to confirm/infirm an insight
+    """Get questions about a product to confirm/infirm an insight
 
     see also doc/explanation/questions.md
     """
 
     def on_get(self, req: falcon.Request, resp: falcon.Response, barcode: str):
         response: JSONType = {}
-        count: int = req.get_param_as_int("count", min_value=1) or 1
+        count: int = req.get_param_as_int("count", min_value=1, default=25)
         lang: str = req.get_param("lang", default="en")
         # If the device_id is not provided as a request parameter, we use the
         # hash of the IPs as a backup.

--- a/robotoff/app/core.py
+++ b/robotoff/app/core.py
@@ -53,7 +53,7 @@ def _add_vote_exclusions(
     elif exclusion.by == SkipVotedType.USERNAME:
         criteria = AnnotationVote.username == exclusion.id
     else:
-        raise ValueError("Unknown SkipVoteType: {exclusion.by}")
+        raise ValueError(f"Unknown SkipVoteType: {exclusion.by}")
 
     return query.join(
         AnnotationVote,
@@ -304,7 +304,7 @@ def save_annotation(
         return ALREADY_ANNOTATED_RESULT
 
     if not trusted_annotator:
-        verified: bool = False
+        verified = False
 
         AnnotationVote.create(
             insight_id=insight_id,

--- a/robotoff/app/core.py
+++ b/robotoff/app/core.py
@@ -81,6 +81,7 @@ def get_insights(
     group_by_value_tag: Optional[bool] = False,
     automatically_processable: Optional[bool] = None,
     campaign: Optional[str] = None,
+    predictor: Optional[str] = None,
 ) -> Iterable[ProductInsight]:
     if server_domain is None:
         server_domain = settings.OFF_SERVER_DOMAIN
@@ -118,6 +119,9 @@ def get_insights(
 
     if campaign is not None:
         where_clauses.append(ProductInsight.campaign.contains(campaign))
+
+    if predictor is not None:
+        where_clauses.append(ProductInsight.predictor == predictor)
 
     query = _add_vote_exclusions(ProductInsight.select(), avoid_voted_on)
 

--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -1083,8 +1083,8 @@ def refresh_all_insights(
     :return: The number of imported insights.
     """
     imported = 0
-    for barcode in (
-        PredictionModel.select(fn.Distinct(PredictionModel.barcode)).scalar().iterator()
+    for (barcode,) in (
+        PredictionModel.select(fn.Distinct(PredictionModel.barcode)).tuples().iterator()
     ):
         logger.info(f"Refreshing insights for product {barcode}")
         imported += refresh_insights(barcode, server_domain, automatic, product_store)

--- a/robotoff/models.py
+++ b/robotoff/models.py
@@ -9,7 +9,6 @@ from playhouse.postgres_ext import BinaryJSONField, PostgresqlExtDatabase
 from playhouse.shortcuts import model_to_dict
 
 from robotoff import settings
-from robotoff.utils.types import JSONType
 
 db = PostgresqlExtDatabase(
     settings.POSTGRES_DB,
@@ -161,16 +160,6 @@ class ProductInsight(BaseModel):
     # Hunger Games) on a subset of products. Each product have 0+ campaign
     # tags
     campaign = BinaryJSONField(null=True, index=True, default=list)
-
-    def serialize(self) -> JSONType:
-        return {
-            "id": str(self.id),
-            "type": self.type,
-            "barcode": self.barcode,
-            "countries": self.countries,
-            "source_image": self.source_image,
-            **self.data,
-        }
 
 
 class Prediction(BaseModel):

--- a/scripts/ocr/dump_ocr.py
+++ b/scripts/ocr/dump_ocr.py
@@ -19,7 +19,7 @@ with gzip.open(str(OUTPUT_PATH), "wb") as output_f:
     for i, image_path_str in enumerate(
         glob.iglob("{}/**/*.jpg".format(ROOT_DIR), recursive=True)
     ):
-        if i % 1000 == 0:
+        if i % 10000 == 0:
             print("step: {}, added: {}".format(i, added))
 
         image_path = Path(image_path_str)

--- a/tests/unit/insights/test_importer.py
+++ b/tests/unit/insights/test_importer.py
@@ -776,6 +776,18 @@ class TestLabelInsightImporter:
                 Product({"code": DEFAULT_BARCODE, "labels_tags": ["en:vegan"]}),
                 [("en:ecoveg", False), ("en:max-havelaar", True)],
             ),
+            (
+                # fr:sans-gluten should be normalized into en:no-gluten
+                [
+                    Prediction(
+                        PredictionType.label,
+                        value_tag="fr:sans-gluten",
+                        automatic_processing=True,
+                    ),
+                ],
+                Product({"code": DEFAULT_BARCODE}),
+                [("en:no-gluten", True)],
+            ),
         ],
     )
     def test_generate_candidates(self, predictions, product, expected, mocker):


### PR DESCRIPTION
A bunch of various fixes/features:

- fix: always serialize insights the same way
- fix: fix min_confidence parameter in /logos/search route
- fix: add a small fix on dump_ocr.py
- fix: make API parameters uniform
- feat: allow to filter insights/question by predictor value
- fix: update brand taxonomy blacklist
- feat: set value_tag to canonical label value during prediction import
- fix: fix refresh_all_insights function