### PR TITLE
fix: fix skip mechanism

### DIFF
--- a/robotoff/app/core.py
+++ b/robotoff/app/core.py
@@ -360,8 +360,8 @@ def save_annotation(
                 raise e
 
         if existing_votes:
-            # If the top annotation has more than 2 votes, consider applying it to the insight.
-            if existing_votes[0].num_votes > 2:
+            # If the top annotation has 3 or more votes, consider applying it to the insight.
+            if existing_votes[0].num_votes >= 3:
                 annotation = existing_votes[0].value
                 verified = True
 


### PR DESCRIPTION
So that this mechanism does not have to be implemented client-side.
The voting mechanism has also been updated: before, all classes
(0, 1, -1) could be considered a valid value. Now, -1 is exclusively
used for users to ignore insights, so it's not considered when
computing vote counts (only 0 and 1 are considered).
Another bug was fixed: when vote counts for 0 and 1 are both >= 2,
we save the insight as invalid (-1) instead of saving it as negative
(0).

Solves #908