### PR TITLE
fix: fix insight import (again!)

### DIFF
--- a/robotoff/cli/insights.py
+++ b/robotoff/cli/insights.py
@@ -95,7 +95,6 @@ def import_insights(
             imported += import_insights_(
                 prediction_batch,
                 server_domain,
-                automatic=False,
                 product_store=product_store,
             )
 

--- a/robotoff/cli/main.py
+++ b/robotoff/cli/main.py
@@ -48,7 +48,7 @@ def regenerate_ocr_insights(
             barcode, ocr_url, DEFAULT_OCR_PREDICTION_TYPES
         )
 
-    imported = import_insights_(predictions, settings.OFF_SERVER_DOMAIN, automatic=True)
+    imported = import_insights_(predictions, settings.OFF_SERVER_DOMAIN)
     logger.info(f"Import finished, {imported} insights imported")
 
 
@@ -347,10 +347,10 @@ def refresh_insights(
 
     if barcode is not None:
         logger.info(f"Refreshing product {barcode}")
-        imported = refresh_insights_(barcode, server_domain, automatic=True)
+        imported = refresh_insights_(barcode, server_domain)
     else:
         logger.info("Refreshing insights of all products")
-        imported = refresh_all_insights(server_domain, automatic=True)
+        imported = refresh_all_insights(server_domain)
 
     logger.info(f"Refreshed insights: {imported}")
 

--- a/robotoff/insights/extraction.py
+++ b/robotoff/insights/extraction.py
@@ -46,6 +46,9 @@ def get_predictions_from_product_name(
         )
         for prediction in predictions:
             prediction.data["source"] = "product_name"
+            # Predictions from product name are not as trustworthy as
+            # predictions from OCR, so disable automatic processing
+            prediction.automatic_processing = False
         predictions_all += predictions
 
     return predictions_all

--- a/robotoff/logos.py
+++ b/robotoff/logos.py
@@ -303,7 +303,7 @@ def import_logo_insights(
         logo_probs.append(probs)
 
     predictions = predict_logo_predictions(selected_logos, logo_probs)
-    imported = import_insights(predictions, server_domain, automatic=True)
+    imported = import_insights(predictions, server_domain)
 
     for logo, probs in zip(selected_logos, logo_probs):
         NotifierFactory.get_notifier().send_logo_notification(logo, probs)
@@ -342,7 +342,7 @@ def generate_insights_from_annotated_logos(
         prediction.source_image = image.source_image
         predictions.append(prediction)
 
-    imported = import_insights(predictions, server_domain, automatic=True)
+    imported = import_insights(predictions, server_domain)
 
     if imported:
         logger.info(f"{imported} logo insights imported after annotation")

--- a/robotoff/scheduler/__init__.py
+++ b/robotoff/scheduler/__init__.py
@@ -225,9 +225,7 @@ def generate_insights():
     product_predictions_iter = predict_from_dataset(dataset, datetime_threshold)
 
     imported = import_insights(
-        product_predictions_iter,
-        server_domain=settings.OFF_SERVER_DOMAIN,
-        automatic=False,
+        product_predictions_iter, server_domain=settings.OFF_SERVER_DOMAIN
     )
     logger.info("{} category insights imported".format(imported))
 

--- a/robotoff/workers/tasks/import_image.py
+++ b/robotoff/workers/tasks/import_image.py
@@ -70,7 +70,7 @@ def import_insights_from_image(
         source_image,
         barcode,
     )
-    imported = import_insights(predictions_all, server_domain, automatic=True)
+    imported = import_insights(predictions_all, server_domain)
     logger.info(f"Import finished, {imported} insights imported")
 
 

--- a/robotoff/workers/tasks/product_updated.py
+++ b/robotoff/workers/tasks/product_updated.py
@@ -28,7 +28,7 @@ def update_insights(barcode: str, server_domain: str):
 
     updated_product_predict_insights(barcode, product_dict, server_domain)
     logger.info("Refreshing insights...")
-    imported = refresh_insights(barcode, server_domain, automatic=True)
+    imported = refresh_insights(barcode, server_domain)
     logger.info(f"{imported} insights created after refresh")
 
 
@@ -64,7 +64,7 @@ def add_category_insight(barcode: str, product: JSONType, server_domain: str) ->
     for prediction in product_predictions:
         prediction.barcode = barcode
 
-    imported = import_insights(product_predictions, server_domain, automatic=True)
+    imported = import_insights(product_predictions, server_domain)
     logger.info(f"{imported} category insight imported for product {barcode}")
 
     return bool(imported)
@@ -81,7 +81,7 @@ def updated_product_predict_insights(
 
     logger.info("Generating predictions from product name...")
     predictions_all = get_predictions_from_product_name(barcode, product_name)
-    imported = import_insights(predictions_all, server_domain, automatic=False)
+    imported = import_insights(predictions_all, server_domain)
     logger.info(f"{imported} insights imported for product {barcode}")
 
     if imported:

--- a/tests/integration/insights/test_category_import.py
+++ b/tests/integration/insights/test_category_import.py
@@ -77,7 +77,6 @@ class TestCategoryImporter:
         imported = import_insights(
             predictions,
             server_domain=settings.OFF_SERVER_DOMAIN,
-            automatic=True,
             product_store=product_store,
         )
         return imported

--- a/tests/integration/insights/test_category_import.py
+++ b/tests/integration/insights/test_category_import.py
@@ -103,12 +103,17 @@ class TestCategoryImporter:
     def test_import_one_same_value_tag(self, predictions):
         """Test when there is a single import, but the value_tag stays the
         same."""
+        original_insights = ProductInsight.select()
+        assert len(original_insights) == 1
+        original_timestamp = original_insights[0].timestamp
         imported = self._run_import(predictions)
-        assert imported == 1
+        assert imported == 0
         # no insight created
-        assert ProductInsight.select().count() == 1
-        insight = ProductInsight().select().limit(1)[0]
+        insights = list(ProductInsight.select())
+        assert len(insights) == 1
+        insight = insights[0]
         assert insight.value_tag == "en:salmons"
+        assert insight.timestamp > original_timestamp
 
     @pytest.mark.parametrize(
         "predictions",

--- a/tests/unit/workers/tasks/test_product_updated.py
+++ b/tests/unit/workers/tasks/test_product_updated.py
@@ -62,7 +62,6 @@ def test_add_category_insight_with_ml_insights(mocker):
             )
         ],
         server_domain,
-        automatic=True,
     )
 
     assert imported


### PR DESCRIPTION
Make voting system work again, and avoid the deletion/creation of insights when there are only minor updates.
Also delete the legacy `automatic` parameter in InsightImporter.

Fixes #975 