### PR TITLE
fix: manually cropping and resizing of logos before CLIP processor

### DIFF
--- a/robotoff/workers/tasks/import_image.py
+++ b/robotoff/workers/tasks/import_image.py
@@ -398,7 +398,7 @@ def run_logo_object_detection(barcode: str, image_url: str, server_domain: str):
 def save_logo_embeddings(logos: list[LogoAnnotation], image: Image.Image):
     """Generate logo embeddings using CLIP model and save them in
     logo_embedding table."""
-    cropped_images = []
+    resized_cropped_images = []
     for logo in logos:
         y_min, x_min, y_max, x_max = logo.bounding_box
         (left, right, top, bottom) = (
@@ -407,8 +407,9 @@ def save_logo_embeddings(logos: list[LogoAnnotation], image: Image.Image):
             y_min * image.height,
             y_max * image.height,
         )
-        cropped_images.append(image.crop((left, top, right, bottom)))
-    embeddings = generate_clip_embedding(cropped_images)
+        cropped_image = image.crop((left, top, right, bottom))
+        resized_cropped_images.append(cropped_image.resize((224,224)))
+    embeddings = generate_clip_embedding(resized_cropped_images)
 
     with db.atomic():
         for i in range(len(logos)):

--- a/robotoff/workers/tasks/import_image.py
+++ b/robotoff/workers/tasks/import_image.py
@@ -117,10 +117,7 @@ def run_import_image_job(
 
 
 def import_insights_from_image(
-    barcode: str,
-    image_url: str,
-    ocr_url: str,
-    server_domain: str,
+    barcode: str, image_url: str, ocr_url: str, server_domain: str
 ):
     image = get_image_from_url(image_url, error_raise=False, session=http_session)
 
@@ -178,7 +175,7 @@ def save_image(
     """Save imported image details in DB."""
     if existing_image_model := ImageModel.get_or_none(source_image=source_image):
         logger.info(
-            f"Image {source_image} already exist in DB, returning existing image",
+            f"Image {source_image} already exist in DB, returning existing image"
         )
         return existing_image_model
 
@@ -408,7 +405,7 @@ def save_logo_embeddings(logos: list[LogoAnnotation], image: Image.Image):
             y_max * image.height,
         )
         cropped_image = image.crop((left, top, right, bottom))
-        resized_cropped_images.append(cropped_image.resize((224,224)))
+        resized_cropped_images.append(cropped_image.resize((224, 224)))
     embeddings = generate_clip_embedding(resized_cropped_images)
 
     with db.atomic():


### PR DESCRIPTION
### What
- Adding manual resizing with PIL library.

### Why
- [CLIP processor]() was used as [the only processing step for logos](https://github.com/openfoodfacts/robotoff/blob/master/robotoff/triton.py#L23). However, to fit the size (224,224) expected by CLIP, it resizes only the smallest dimension of the image and then crops the logo. We don't want to loose data by cropping.