### PR TITLE
feat: allow to know where regex-based detections are located in the image

### DIFF
--- a/robotoff/insights/normalize.py
+++ b/robotoff/insights/normalize.py
@@ -1,4 +1,4 @@
-from robotoff.utils.text import strip_accents_ascii
+from robotoff.utils.text import strip_accents_v1
 
 
 def normalize_emb_code(emb_code: str):
@@ -10,7 +10,7 @@ def normalize_emb_code(emb_code: str):
         emb_code.strip().lower().replace(" ", "").replace("-", "").replace(".", "")
     )
 
-    emb_code = strip_accents_ascii(emb_code)
+    emb_code = strip_accents_v1(emb_code)
 
     """if the code ends with "ce" replace it with "ec"
     here "fr40261001ce" becomes "fr40261001ec"

--- a/robotoff/prediction/category/matcher.py
+++ b/robotoff/prediction/category/matcher.py
@@ -15,7 +15,7 @@ from robotoff.types import PredictionType
 from robotoff.utils import dump_json, get_logger, load_json
 from robotoff.utils.text import (
     get_lemmatizing_nlp,
-    strip_accents_ascii,
+    strip_accents_v1,
     strip_consecutive_spaces,
 )
 
@@ -169,7 +169,7 @@ def process(text: str, lang: str) -> str:
             continue
         lemmas.append(token.lemma_)
 
-    return strip_accents_ascii(" ".join(lemmas))
+    return strip_accents_v1(" ".join(lemmas))
 
 
 def generate_match_maps(taxonomy_type: str) -> MatchMapType:

--- a/robotoff/prediction/category/neural/keras_category_classifier_3_0/__init__.py
+++ b/robotoff/prediction/category/neural/keras_category_classifier_3_0/__init__.py
@@ -210,7 +210,7 @@ def fetch_ocr_texts(product: JSONType) -> list[str]:
         ocr_url = generate_json_ocr_url(barcode, image_id)
         ocr_result = get_ocr_result(ocr_url, http_session, error_raise=False)
         if ocr_result:
-            ocr_texts.append(ocr_result.get_full_text())
+            ocr_texts.append(ocr_result.get_text())
 
     return ocr_texts
 

--- a/robotoff/prediction/category/neural/keras_category_classifier_3_0/__init__.py
+++ b/robotoff/prediction/category/neural/keras_category_classifier_3_0/__init__.py
@@ -210,7 +210,7 @@ def fetch_ocr_texts(product: JSONType) -> list[str]:
         ocr_url = generate_json_ocr_url(barcode, image_id)
         ocr_result = get_ocr_result(ocr_url, http_session, error_raise=False)
         if ocr_result:
-            ocr_texts.append(ocr_result.get_full_text())
+            ocr_texts.append(ocr_result.get_full_text_contiguous())
 
     return ocr_texts
 

--- a/robotoff/prediction/category/neural/keras_category_classifier_3_0/__init__.py
+++ b/robotoff/prediction/category/neural/keras_category_classifier_3_0/__init__.py
@@ -210,7 +210,7 @@ def fetch_ocr_texts(product: JSONType) -> list[str]:
         ocr_url = generate_json_ocr_url(barcode, image_id)
         ocr_result = get_ocr_result(ocr_url, http_session, error_raise=False)
         if ocr_result:
-            ocr_texts.append(ocr_result.get_text())
+            ocr_texts.append(ocr_result.get_full_text())
 
     return ocr_texts
 

--- a/robotoff/prediction/ocr/category.py
+++ b/robotoff/prediction/ocr/category.py
@@ -35,46 +35,42 @@ AOC_REGEX = {
         OCRRegex(
             # re.compile(r"(?<=appellation\s).*(?=(\scontr[ôo]l[ée]e)|(\sprot[ée]g[ée]e))"),
             re.compile(
-                r"(appellation)\s*(?P<category>.+)\s*(contr[ôo]l[ée]e|prot[ée]g[ée]e)"
+                r"(appellation)\s*(?P<category>.+)\s*(contr[ôo]l[ée]e|prot[ée]g[ée]e)",
+                re.I,
             ),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
             processing_func=category_taxonomisation,
         ),
         OCRRegex(
             re.compile(
-                r"(?P<category>.+)\s*(appellation d'origine contr[ôo]l[ée]e|appellation d'origine prot[ée]g[ée]e)"
+                r"(?P<category>.+)\s*(appellation d'origine contr[ôo]l[ée]e|appellation d'origine prot[ée]g[ée]e)",
+                re.I,
             ),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
             processing_func=category_taxonomisation,
         ),
     ],
     "es:": [
         OCRRegex(
-            re.compile(r"(?P<category>.+)(\s*denominacion de origen protegida)"),
+            re.compile(r"(?P<category>.+)(\s*denominacion de origen protegida)", re.I),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
             processing_func=category_taxonomisation,
         ),
         OCRRegex(
-            re.compile(r"(denominacion de origen protegida\s*)(?P<category>.+)"),
+            re.compile(r"(denominacion de origen protegida\s*)(?P<category>.+)", re.I),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
             processing_func=category_taxonomisation,
         ),
     ],
     "en:": [
         OCRRegex(
-            re.compile(r"(?P<category>.+)\s*(aop|dop|pdo)"),
+            re.compile(r"(?P<category>.+)\s*(aop|dop|pdo)", re.I),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
             processing_func=category_taxonomisation,
         ),
         OCRRegex(
-            re.compile(r"(aop|dop|pdo)\s*(?P<category>.+)"),
+            re.compile(r"(aop|dop|pdo)\s*(?P<category>.+)", re.I),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
             processing_func=category_taxonomisation,
         ),
     ],

--- a/robotoff/prediction/ocr/category.py
+++ b/robotoff/prediction/ocr/category.py
@@ -7,7 +7,7 @@ from robotoff.taxonomy import get_taxonomy
 from robotoff.types import PredictionType
 from robotoff.utils import get_logger
 
-from .dataclass import OCRRegex, OCRResult, get_text
+from .dataclass import OCRField, OCRRegex, OCRResult, get_text
 
 logger = get_logger(__name__)
 
@@ -38,6 +38,7 @@ AOC_REGEX = {
                 r"(appellation)\s*(?P<category>.+)\s*(contr[ôo]l[ée]e|prot[ée]g[ée]e)",
                 re.I,
             ),
+            field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
         OCRRegex(
@@ -45,26 +46,31 @@ AOC_REGEX = {
                 r"(?P<category>.+)\s*(appellation d'origine contr[ôo]l[ée]e|appellation d'origine prot[ée]g[ée]e)",
                 re.I,
             ),
+            field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
     ],
     "es:": [
         OCRRegex(
             re.compile(r"(?P<category>.+)(\s*denominacion de origen protegida)", re.I),
+            field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
         OCRRegex(
             re.compile(r"(denominacion de origen protegida\s*)(?P<category>.+)", re.I),
+            field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
     ],
     "en:": [
         OCRRegex(
             re.compile(r"(?P<category>.+)\s*(aop|dop|pdo)", re.I),
+            field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
         OCRRegex(
             re.compile(r"(aop|dop|pdo)\s*(?P<category>.+)", re.I),
+            field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
     ],
@@ -82,7 +88,7 @@ def find_category(content: Union[OCRResult, str]) -> list[Prediction]:
 
     for lang, regex_list in AOC_REGEX.items():
         for ocr_regex in regex_list:
-            text = get_text(content)
+            text = get_text(content, ocr_regex)
 
             if not text:
                 continue

--- a/robotoff/prediction/ocr/category.py
+++ b/robotoff/prediction/ocr/category.py
@@ -7,7 +7,7 @@ from robotoff.taxonomy import get_taxonomy
 from robotoff.types import PredictionType
 from robotoff.utils import get_logger
 
-from .dataclass import OCRField, OCRRegex, OCRResult, get_text
+from .dataclass import OCRRegex, OCRResult, get_text
 
 logger = get_logger(__name__)
 
@@ -38,7 +38,6 @@ AOC_REGEX = {
                 r"(appellation)\s*(?P<category>.+)\s*(contr[ôo]l[ée]e|prot[ée]g[ée]e)",
                 re.I,
             ),
-            field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
         OCRRegex(
@@ -46,31 +45,26 @@ AOC_REGEX = {
                 r"(?P<category>.+)\s*(appellation d'origine contr[ôo]l[ée]e|appellation d'origine prot[ée]g[ée]e)",
                 re.I,
             ),
-            field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
     ],
     "es:": [
         OCRRegex(
             re.compile(r"(?P<category>.+)(\s*denominacion de origen protegida)", re.I),
-            field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
         OCRRegex(
             re.compile(r"(denominacion de origen protegida\s*)(?P<category>.+)", re.I),
-            field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
     ],
     "en:": [
         OCRRegex(
             re.compile(r"(?P<category>.+)\s*(aop|dop|pdo)", re.I),
-            field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
         OCRRegex(
             re.compile(r"(aop|dop|pdo)\s*(?P<category>.+)", re.I),
-            field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
     ],
@@ -88,7 +82,7 @@ def find_category(content: Union[OCRResult, str]) -> list[Prediction]:
 
     for lang, regex_list in AOC_REGEX.items():
         for ocr_regex in regex_list:
-            text = get_text(content, ocr_regex)
+            text = get_text(content)
 
             if not text:
                 continue

--- a/robotoff/prediction/ocr/dataclass.py
+++ b/robotoff/prediction/ocr/dataclass.py
@@ -8,6 +8,9 @@ from typing import Callable, Optional, Union
 from robotoff.types import JSONType
 from robotoff.utils import get_logger
 
+# Some classes documentation were adapted from Google documentation on
+# https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.Symbol
+
 MULTIPLE_SPACES_REGEX = re.compile(r" {2,}")
 
 logger = get_logger(__name__)
@@ -248,6 +251,12 @@ def get_text(
 
 
 class OCRFullTextAnnotation:
+    """TextAnnotation contains a structured representation of OCR extracted
+    text. The hierarchy of an OCR extracted text structure is like this:
+    TextAnnotation -> Page -> Block -> Paragraph -> Word -> Symbol Each
+    structural component, starting from Page, may further have their own
+    properties. Properties describe detected languages, breaks etc.."""
+
     __slots__ = (
         "text",
         "text_lower",
@@ -301,6 +310,8 @@ class OCRFullTextAnnotation:
 
 
 class TextAnnotationPage:
+    """Detected page from OCR."""
+
     def __init__(self, data: JSONType):
         self.width = data["width"]
         self.height = data["height"]
@@ -326,6 +337,8 @@ class TextAnnotationPage:
 
 
 class Block:
+    """Logical element on the page."""
+
     def __init__(self, data: JSONType):
         self.type = data["blockType"]
         self.paragraphs: list[Paragraph] = [
@@ -362,6 +375,9 @@ class Block:
 
 
 class Paragraph:
+    """Structural unit of text representing a number of words in certain
+    order."""
+
     def __init__(self, data: JSONType):
         self.words: list[Word] = [Word(word) for word in data["words"]]
 
@@ -397,6 +413,8 @@ class Paragraph:
 
 
 class Word:
+    """A word representation."""
+
     __slots__ = ("bounding_poly", "symbols", "languages")
 
     def __init__(self, data: JSONType):
@@ -457,6 +475,8 @@ class Word:
 
 
 class Symbol:
+    """A single symbol representation."""
+
     __slots__ = ("bounding_poly", "text", "confidence", "symbol_break")
 
     def __init__(self, data: JSONType):
@@ -480,10 +500,22 @@ class Symbol:
 
 
 class DetectedBreak:
+    """Detected start or end of a structural component."""
+
     __slots__ = ("type", "is_prefix")
 
     def __init__(self, data: JSONType):
+        # Detected break type.
+        # Enum to denote the type of break found. New line, space etc.
+        # UNKNOWN: Unknown break label type.
+        # SPACE: Regular space.
+        # SURE_SPACE: Sure space (very wide).
+        # EOL_SURE_SPACE: Line-wrapping break.
+        # HYPHEN: End-line hyphen that is not present in text; does not co-occur
+        # with SPACE, LEADER_SPACE, or LINE_BREAK.
+        # LINE_BREAK: Line break that ends a paragraph.
         self.type = data["type"]
+        # True if break prepends the element.
         self.is_prefix = data.get("isPrefix", False)
 
     def __repr__(self):

--- a/robotoff/prediction/ocr/dataclass.py
+++ b/robotoff/prediction/ocr/dataclass.py
@@ -628,7 +628,7 @@ class Paragraph:
         selected = []
         remaining = True
         for word in self.words:
-            if word.start_idx >= start_idx and word.start_idx < end_idx:
+            if word.end_idx >= start_idx and word.start_idx < end_idx:
                 selected.append(word)
             if word.end_idx >= end_idx:
                 remaining = False

--- a/robotoff/prediction/ocr/dataclass.py
+++ b/robotoff/prediction/ocr/dataclass.py
@@ -21,25 +21,17 @@ class OCRParsingException(Exception):
     pass
 
 
-class OCRField(enum.Enum):
-    full_text = 1
-    full_text_contiguous = 2
-    text_annotations = 3
-
-
 class OCRRegex:
-    __slots__ = ("regex", "field", "processing_func", "priority", "notify")
+    __slots__ = ("regex", "processing_func", "priority", "notify")
 
     def __init__(
         self,
         regex: re.Pattern,
-        field: OCRField,
         processing_func: Optional[Callable] = None,
         priority: Optional[int] = None,
         notify: bool = False,
     ):
         self.regex: re.Pattern = regex
-        self.field: OCRField = field
         self.processing_func: Optional[Callable] = processing_func
         self.priority = priority
         self.notify = notify
@@ -126,48 +118,13 @@ class OCRResult:
                 data["safeSearchAnnotation"]
             )
 
-    def get_full_text(self) -> str:
-        if self.full_text_annotation is not None:
-            return self.full_text_annotation.api_text
-
-        return ""
-
-    def get_full_text_contiguous(self) -> str:
-        if self.full_text_annotation is not None:
-            return self.full_text_annotation.api_text
-
-        return ""
-
     def get_text_annotations(self) -> str:
         return self.text_annotations_str
 
-    def _get_text(self, field: OCRField) -> str:
-        if field == OCRField.full_text:
-            text = self.get_full_text()
-
-            if text is None:
-                # If there is no full text, get text annotations as fallback
-                return self.get_text_annotations()
-            else:
-                return text
-
-        elif field == OCRField.full_text_contiguous:
-            text = self.get_full_text_contiguous()
-
-            if text is None:
-                # If there is no full text, get text annotations as fallback
-                return self.get_text_annotations()
-            else:
-                return text
-
-        elif field == OCRField.text_annotations:
-            return self.get_text_annotations()
-
-        else:
-            raise ValueError("invalid field: {}".format(field))
-
-    def get_text(self, ocr_regex: OCRRegex) -> str:
-        return self._get_text(ocr_regex.field)
+    def get_text(self) -> str:
+        return (
+            "" if self.full_text_annotation is None else self.full_text_annotation.text
+        )
 
     def get_logo_annotations(self) -> list["LogoAnnotation"]:
         return self.logo_annotations
@@ -228,24 +185,8 @@ class OCRResult:
         return None
 
 
-def get_text(
-    content: Union[OCRResult, str], ocr_regex: Optional[OCRRegex] = None
-) -> str:
-    if isinstance(content, str):
-        return content
-
-    elif isinstance(content, OCRResult):
-        if ocr_regex:
-            return content.get_text(ocr_regex)
-        else:
-            text = content.get_full_text_contiguous()
-
-            if not text:
-                text = content.get_text_annotations()
-
-            return text
-
-    raise TypeError("invalid type: {}".format(type(content)))
+def get_text(content: Union[OCRResult, str]) -> str:
+    return content if isinstance(content, str) else content.get_text()
 
 
 class OCRFullTextAnnotation:
@@ -284,7 +225,7 @@ class OCRFullTextAnnotation:
             self.pages.append(page)
         # Join page texts with a `|` character, to avoid matches to span over
         # multiple pages
-        self.text = "|".join(text_list)
+        self.text: str = "|".join(text_list)
         # Replace line break with space characters to allow matches spanning
         # multiple lines
         # We used to replace consecutive spaces (2+) with a single space so that

--- a/robotoff/prediction/ocr/dataclass.py
+++ b/robotoff/prediction/ocr/dataclass.py
@@ -409,7 +409,7 @@ class Paragraph:
 
     def get_text(self) -> str:
         """Return the text of the paragraph, by concatenating the words."""
-        return "".join(w.get_text() for w in self.words)
+        return "".join(w.text for w in self.words)
 
 
 class Word:
@@ -429,20 +429,21 @@ class Word:
                 DetectedLanguage(lang) for lang in data["property"]["detectedLanguages"]
             ]
 
-    def get_text(self) -> str:
+    @property
+    def text(self):
+        if not self._text:
+            self._text = self._get_text()
+
+        return self._text
+
+    def _get_text(self) -> str:
         text_list = []
         for symbol in self.symbols:
-            symbol_str = ""
-
             if symbol.symbol_break and symbol.symbol_break.is_prefix:
-                symbol_str = symbol.symbol_break.get_value()
-
-            symbol_str += symbol.text
-
+                text_list.append(symbol.symbol_break.get_value())
+            text_list.append(symbol.text)
             if symbol.symbol_break and not symbol.symbol_break.is_prefix:
-                symbol_str += symbol.symbol_break.get_value()
-
-            text_list.append(symbol_str)
+                text_list.append(symbol.symbol_break.get_value())
 
         return "".join(text_list)
 

--- a/robotoff/prediction/ocr/dataclass.py
+++ b/robotoff/prediction/ocr/dataclass.py
@@ -293,7 +293,9 @@ class OCRFullTextAnnotation:
         # This way, the word offsets (word.start_idx, word.end_idx) match the
         # FullTextAnnotation text, and we can very easily determine the position
         # of the matched words
-        self.continuous_text: str = self.text.replace("\n", " ")
+        self.continuous_text: str = "|".join(
+            t.replace("|", " ").replace("\n", " ") for t in text_list
+        )
         # Here we use a accent stripping function that don't delete or
         # introduce any character, so that word offsets are preserved
         self.unnaccented_text = strip_accents_v2(self.continuous_text, keep_length=True)
@@ -360,10 +362,12 @@ class TextAnnotationPage:
         text_list: list[str] = []
         for block_data in data["blocks"]:
             block = Block(block_data, initial_offset)
+            # We add a '|' between each block, so that it's not possible to
+            # match over several blocks, so we add + 1 to offset
             initial_offset += len(block.text) + 1
             text_list.append(block.text)
             self.blocks.append(block)
-        self.text = "".join(text_list)
+        self.text = "|".join(text_list)
 
     def get_languages(self) -> dict[str, int]:
         counts: dict[str, int] = defaultdict(int)

--- a/robotoff/prediction/ocr/dataclass.py
+++ b/robotoff/prediction/ocr/dataclass.py
@@ -225,7 +225,15 @@ class OCRResult:
         words = self.get_words_from_indices(start_idx, end_idx, raises)
 
         if words is not None:
-            return compute_intersection_bounding_box(words)
+            if words:
+                return compute_intersection_bounding_box(words)
+            else:
+                logger.warning(
+                    "no words found in %s, (start: %d, end: %d)",
+                    self.get_full_text_contiguous(),
+                    start_idx,
+                    end_idx,
+                )
 
         return None
 
@@ -268,6 +276,18 @@ def get_text(
             return text
 
     raise TypeError("invalid type: {}".format(type(content)))
+
+
+def get_match_bounding_box(
+    content: Union[OCRResult, str], start_idx: int, end_idx: int
+):
+    """Return a bounding box that include all words that span from
+    `start_idx` to `end_idx` if `content` is an OCRResult and None otherwise.
+    """
+    if isinstance(content, str):
+        return None
+
+    return content.get_match_bounding_box(start_idx, end_idx)
 
 
 class OCRFullTextAnnotation:

--- a/robotoff/prediction/ocr/dataclass.py
+++ b/robotoff/prediction/ocr/dataclass.py
@@ -307,12 +307,10 @@ class TextAnnotationPage:
         text_list: list[str] = []
         for block_data in data["blocks"]:
             block = Block(block_data, initial_offset)
-            # We add a '|' between each block, so that it's not possible to
-            # match over several blocks, so we add + 1 to offset
             initial_offset += len(block.text) + 1
             text_list.append(block.text)
             self.blocks.append(block)
-        self.text = "|".join(text_list)
+        self.text = "".join(text_list)
 
     def get_languages(self) -> dict[str, int]:
         counts: dict[str, int] = defaultdict(int)

--- a/robotoff/prediction/ocr/dataclass.py
+++ b/robotoff/prediction/ocr/dataclass.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional, Union
 
 from robotoff.types import JSONType
 from robotoff.utils import get_logger
-from robotoff.utils.text import strip_accents
+from robotoff.utils.text import strip_accents_v2
 
 # Some classes documentation were adapted from Google documentation on
 # https://cloud.google.com/vision/docs/reference/rpc/google.cloud.vision.v1#google.cloud.vision.v1.Symbol
@@ -122,6 +122,11 @@ class OCRResult:
         return self.text_annotations_str
 
     def get_text(self) -> str:
+        """Return the OCR text.
+
+        If full text annotations are not available, an empty string is
+        returned.
+        """
         return (
             "" if self.full_text_annotation is None else self.full_text_annotation.text
         )
@@ -238,7 +243,7 @@ class OCRFullTextAnnotation:
         self.continuous_text = self.text.replace("\n", " ")
         # Here we use a accent stripping function that don't delete or
         # introduce any character, so that word offsets are preserved
-        self.unnaccented_text = strip_accents(self.continuous_text, keep_length=True)
+        self.unnaccented_text = strip_accents_v2(self.continuous_text, keep_length=True)
 
     def get_languages(self) -> dict[str, int]:
         counts: dict[str, int] = defaultdict(int)

--- a/robotoff/prediction/ocr/expiration_date.py
+++ b/robotoff/prediction/ocr/expiration_date.py
@@ -6,7 +6,7 @@ from typing import Optional, Union
 from robotoff.prediction.types import Prediction
 from robotoff.types import PredictionType
 
-from .dataclass import OCRField, OCRRegex, OCRResult, get_text
+from .dataclass import OCRRegex, OCRResult, get_text
 
 
 def process_full_digits_expiration_date(match, short: bool) -> Optional[datetime.date]:
@@ -30,14 +30,12 @@ def process_full_digits_expiration_date(match, short: bool) -> Optional[datetime
 EXPIRATION_DATE_REGEX: dict[str, OCRRegex] = {
     "full_digits_short": OCRRegex(
         re.compile(r"(?<!\d)(\d{2})[-./](\d{2})[-./](\d{2})(?!\d)"),
-        field=OCRField.full_text,
         processing_func=functools.partial(
             process_full_digits_expiration_date, short=True
         ),
     ),
     "full_digits_long": OCRRegex(
         re.compile(r"(?<!\d)(\d{2})[-./](\d{2})[-./](\d{4})(?!\d)"),
-        field=OCRField.full_text,
         processing_func=functools.partial(
             process_full_digits_expiration_date, short=False
         ),
@@ -51,7 +49,7 @@ def find_expiration_date(content: Union[OCRResult, str]) -> list[Prediction]:
     results: list[Prediction] = []
 
     for type_, ocr_regex in EXPIRATION_DATE_REGEX.items():
-        text = get_text(content, ocr_regex)
+        text = get_text(content)
 
         if not text:
             continue

--- a/robotoff/prediction/ocr/expiration_date.py
+++ b/robotoff/prediction/ocr/expiration_date.py
@@ -31,7 +31,6 @@ EXPIRATION_DATE_REGEX: dict[str, OCRRegex] = {
     "full_digits_short": OCRRegex(
         re.compile(r"(?<!\d)(\d{2})[-./](\d{2})[-./](\d{2})(?!\d)"),
         field=OCRField.full_text,
-        lowercase=False,
         processing_func=functools.partial(
             process_full_digits_expiration_date, short=True
         ),
@@ -39,7 +38,6 @@ EXPIRATION_DATE_REGEX: dict[str, OCRRegex] = {
     "full_digits_long": OCRRegex(
         re.compile(r"(?<!\d)(\d{2})[-./](\d{2})[-./](\d{4})(?!\d)"),
         field=OCRField.full_text,
-        lowercase=False,
         processing_func=functools.partial(
             process_full_digits_expiration_date, short=False
         ),

--- a/robotoff/prediction/ocr/expiration_date.py
+++ b/robotoff/prediction/ocr/expiration_date.py
@@ -6,7 +6,7 @@ from typing import Optional, Union
 from robotoff.prediction.types import Prediction
 from robotoff.types import PredictionType
 
-from .dataclass import OCRField, OCRRegex, OCRResult, get_text
+from .dataclass import OCRField, OCRRegex, OCRResult, get_match_bounding_box, get_text
 
 
 def process_full_digits_expiration_date(match, short: bool) -> Optional[datetime.date]:
@@ -73,11 +73,18 @@ def find_expiration_date(content: Union[OCRResult, str]) -> list[Prediction]:
             # Format dates according to ISO 8601
             value = date.strftime("%Y-%m-%d")
 
+            data = {"raw": raw, "type": type_, "notify": ocr_regex.notify}
+            if (
+                bounding_box := get_match_bounding_box(
+                    content, match.start(), match.end()
+                )
+            ) is not None:
+                data["bounding_box_absolute"] = bounding_box
             results.append(
                 Prediction(
                     value=value,
                     type=PredictionType.expiration_date,
-                    data={"raw": raw, "type": type_, "notify": ocr_regex.notify},
+                    data=data,
                     automatic_processing=True,
                 )
             )

--- a/robotoff/prediction/ocr/expiration_date.py
+++ b/robotoff/prediction/ocr/expiration_date.py
@@ -6,7 +6,7 @@ from typing import Optional, Union
 from robotoff.prediction.types import Prediction
 from robotoff.types import PredictionType
 
-from .dataclass import OCRRegex, OCRResult, get_text
+from .dataclass import OCRField, OCRRegex, OCRResult, get_text
 
 
 def process_full_digits_expiration_date(match, short: bool) -> Optional[datetime.date]:
@@ -30,12 +30,14 @@ def process_full_digits_expiration_date(match, short: bool) -> Optional[datetime
 EXPIRATION_DATE_REGEX: dict[str, OCRRegex] = {
     "full_digits_short": OCRRegex(
         re.compile(r"(?<!\d)(\d{2})[-./](\d{2})[-./](\d{2})(?!\d)"),
+        field=OCRField.full_text,
         processing_func=functools.partial(
             process_full_digits_expiration_date, short=True
         ),
     ),
     "full_digits_long": OCRRegex(
         re.compile(r"(?<!\d)(\d{2})[-./](\d{2})[-./](\d{4})(?!\d)"),
+        field=OCRField.full_text,
         processing_func=functools.partial(
             process_full_digits_expiration_date, short=False
         ),
@@ -49,7 +51,7 @@ def find_expiration_date(content: Union[OCRResult, str]) -> list[Prediction]:
     results: list[Prediction] = []
 
     for type_, ocr_regex in EXPIRATION_DATE_REGEX.items():
-        text = get_text(content)
+        text = get_text(content, ocr_regex)
 
         if not text:
             continue

--- a/robotoff/prediction/ocr/grammar.py
+++ b/robotoff/prediction/ocr/grammar.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from robotoff.taxonomy import Taxonomy, TaxonomyType, get_taxonomy
 from robotoff.utils import dump_json, get_logger
-from robotoff.utils.text import strip_accents
+from robotoff.utils.text import strip_accents_v2
 
 logger = get_logger(__name__)
 
@@ -14,7 +14,7 @@ def normalize_string(text: str, lowercase: bool, strip_accent: bool) -> str:
     if lowercase:
         text = text.lower()
     if strip_accent:
-        text = strip_accents(text)
+        text = strip_accents_v2(text)
     return text
 
 

--- a/robotoff/prediction/ocr/grammar.py
+++ b/robotoff/prediction/ocr/grammar.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from robotoff.taxonomy import Taxonomy, TaxonomyType, get_taxonomy
 from robotoff.utils import dump_json, get_logger
-from robotoff.utils.text import strip_accents_ascii_v2
+from robotoff.utils.text import strip_accents
 
 logger = get_logger(__name__)
 
@@ -14,7 +14,7 @@ def normalize_string(text: str, lowercase: bool, strip_accent: bool) -> str:
     if lowercase:
         text = text.lower()
     if strip_accent:
-        text = strip_accents_ascii_v2(text)
+        text = strip_accents(text)
     return text
 
 

--- a/robotoff/prediction/ocr/label.py
+++ b/robotoff/prediction/ocr/label.py
@@ -9,7 +9,7 @@ from robotoff.types import PredictionType
 from robotoff.utils import get_logger, text_file_iter
 from robotoff.utils.cache import CachedStore
 
-from .dataclass import OCRField, OCRRegex, OCRResult, get_text
+from .dataclass import OCRRegex, OCRResult, get_text
 from .utils import generate_keyword_processor
 
 logger = get_logger(__name__)
@@ -44,7 +44,6 @@ LABELS_REGEX = {
             re.compile(
                 r"|".join([r"(?:{})".format(x) for x in EN_ORGANIC_REGEX_STR]), re.I
             ),
-            field=OCRField.full_text_contiguous,
         ),
     ],
     "xx-bio-xx": [
@@ -54,85 +53,57 @@ LABELS_REGEX = {
             re.compile(
                 r"(?<![a-zA-Z])([A-Z]{2})[\-\s.](BIO|ÖKO|OKO|EKO|ØKO|ORG|Bio)[\-\s.](\d{2,3})"
             ),
-            field=OCRField.text_annotations,
             processing_func=process_eu_bio_label_code,
         ),
         # Spain specific regex
         OCRRegex(
             re.compile(r"(?<![a-zA-Z])ES[\-\s.]ECO[\-\s.](\d{3})[\-\s.]([A-Z]{2,3})"),
-            field=OCRField.text_annotations,
             processing_func=process_es_bio_label_code,
         ),
     ],
     "fr:ab-agriculture-biologique": [
-        OCRRegex(
-            re.compile(r"certifi[ée] ab[\s.,)]", re.I),
-            field=OCRField.full_text_contiguous,
-        ),
+        OCRRegex(re.compile(r"certifi[ée] ab[\s.,)]", re.I))
     ],
     "en:pgi": [
         OCRRegex(
             re.compile(
                 r"indication g[ée]ographique prot[eé]g[eé]e|Indicazione geografica protetta|geschützte geografische angabe",
                 re.I,
-            ),
-            field=OCRField.full_text_contiguous,
+            )
         ),
-        OCRRegex(
-            re.compile(r"(?<!\w)(?:IGP|BGA|PGI)(?!\w)"),
-            field=OCRField.full_text_contiguous,
-        ),
+        OCRRegex(re.compile(r"(?<!\w)(?:IGP|BGA|PGI)(?!\w)")),
     ],
     "fr:label-rouge": [
+        OCRRegex(re.compile(r"d[ée]cret du 0?5[./]01[./]07", re.I)),
         OCRRegex(
-            re.compile(r"d[ée]cret du 0?5[./]01[./]07", re.I),
-            field=OCRField.full_text_contiguous,
-        ),
-        OCRRegex(
-            re.compile(r"(?<!\w)homologation(?: n°?)? ?la ?\d{2}\/\d{2}(?!\w)", re.I),
-            field=OCRField.full_text_contiguous,
+            re.compile(r"(?<!\w)homologation(?: n°?)? ?la ?\d{2}\/\d{2}(?!\w)", re.I)
         ),
     ],
     "en:pdo": [
-        OCRRegex(
-            re.compile(r"(?<!\w)(?:PDO|AOP|DOP)(?!\w)"),
-            field=OCRField.full_text_contiguous,
-        ),
-        OCRRegex(
-            re.compile(r"appellation d'origine prot[eé]g[eé]e", re.I),
-            field=OCRField.full_text_contiguous,
-        ),
+        OCRRegex(re.compile(r"(?<!\w)(?:PDO|AOP|DOP)(?!\w)")),
+        OCRRegex(re.compile(r"appellation d'origine prot[eé]g[eé]e", re.I)),
     ],
-    "fr:aoc": [
-        OCRRegex(
-            re.compile(r"(?<!\w)(?:AOC)(?!\w)"), field=OCRField.full_text_contiguous
-        ),
-    ],
+    "fr:aoc": [OCRRegex(re.compile(r"(?<!\w)(?:AOC)(?!\w)"))],
     "en:nutriscore": [
-        OCRRegex(re.compile(r"NUTRI-SCORE"), field=OCRField.full_text),
+        OCRRegex(re.compile(r"NUTRI-SCORE")),
     ],
     "en:eu-non-eu-agriculture": [
         OCRRegex(
             re.compile(
                 r"agriculture ue\s?/\s?non\s?(?:-\s?)?ue|eu\s?/\s?non\s?(?:-\s?)?eu agriculture",
                 re.I,
-            ),
-            field=OCRField.full_text_contiguous,
+            )
         ),
     ],
     "en:eu-agriculture": [
         # The negative lookafter/lookbehind forbid matching "agriculture ue/non ue"
-        OCRRegex(
-            re.compile(r"agriculture ue(?!\s?/)|(?<!-)\s?eu agriculture", re.I),
-            field=OCRField.full_text_contiguous,
-        ),
+        OCRRegex(re.compile(r"agriculture ue(?!\s?/)|(?<!-)\s?eu agriculture", re.I)),
     ],
     "en:non-eu-agriculture": [
         OCRRegex(
             re.compile(
                 r"agriculture non\s?(?:-\s?)?ue|non\s?(?:-\s?)?eu agriculture", re.I
             ),
-            field=OCRField.full_text_contiguous,
         ),
     ],
     "en:no-preservatives": [
@@ -141,7 +112,6 @@ LABELS_REGEX = {
                 r"senza conservanti(?! arti)|без консервантов|conserveermiddelvrij|(?<!\w)(?:sans|ni) conservateur(?!s? arti)|fără conservanți|no preservative|sin conservante(?!s? arti)|ohne konservierungsstoffe",
                 re.I,
             ),
-            field=OCRField.full_text_contiguous,
         ),
     ],
     "en:no-flavors": [
@@ -150,7 +120,6 @@ LABELS_REGEX = {
                 r"без ароматизаторов|senza aromi|zonder toegevoegde smaakstoffen|(?<!\w)(?:sans|ni) ar[ôo]mes? ajout[ée]s|sin aromas?|ohne zusatz von aromen|no flavors?",
                 re.I,
             ),
-            field=OCRField.full_text_contiguous,
         ),
     ],
     "en:no-artificial-flavors": [
@@ -159,7 +128,6 @@ LABELS_REGEX = {
                 r"без искусственных ароматизаторов|ohne künstliche aromen|sin aromas? artificiales?|vrij van kunstmatige smaakstoffen|(?<!\w)(?:sans|ni) ar[ôo]mes? artificiels?|no artificial flavors?",
                 re.I,
             ),
-            field=OCRField.full_text_contiguous,
         ),
     ],
     "en:no-colorings": [
@@ -168,7 +136,6 @@ LABELS_REGEX = {
                 r"no colorings?|no colourants?|ohne farbstoffzusatz|(?<!\w)(?:sans|ni) colorants?|zonder kleurstoffen|sin colorantes?|без красителей|senza coloranti",
                 re.I,
             ),
-            field=OCRField.full_text_contiguous,
         ),
     ],
     "en:no-additives": [
@@ -177,7 +144,6 @@ LABELS_REGEX = {
                 r"zonder toevoegingen|sin aditivos(?! arti)|(?<!\w)(?:sans|ni) additif(?!s? arti)|ohne zusätze|no additives?",
                 re.I,
             ),
-            field=OCRField.full_text_contiguous,
         ),
     ],
 }
@@ -236,7 +202,7 @@ def find_labels(content: Union[OCRResult, str]) -> list[Prediction]:
 
     for label_tag, regex_list in LABELS_REGEX.items():
         for ocr_regex in regex_list:
-            text = get_text(content, ocr_regex)
+            text = get_text(content)
 
             if not text:
                 continue

--- a/robotoff/prediction/ocr/label.py
+++ b/robotoff/prediction/ocr/label.py
@@ -41,9 +41,10 @@ EN_ORGANIC_REGEX_STR = [
 LABELS_REGEX = {
     "en:organic": [
         OCRRegex(
-            re.compile(r"|".join([r"(?:{})".format(x) for x in EN_ORGANIC_REGEX_STR])),
+            re.compile(
+                r"|".join([r"(?:{})".format(x) for x in EN_ORGANIC_REGEX_STR]), re.I
+            ),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
         ),
     ],
     "xx-bio-xx": [
@@ -54,143 +55,129 @@ LABELS_REGEX = {
                 r"(?<![a-zA-Z])([A-Z]{2})[\-\s.](BIO|ÖKO|OKO|EKO|ØKO|ORG|Bio)[\-\s.](\d{2,3})"
             ),
             field=OCRField.text_annotations,
-            lowercase=False,
             processing_func=process_eu_bio_label_code,
         ),
         # Spain specific regex
         OCRRegex(
             re.compile(r"(?<![a-zA-Z])ES[\-\s.]ECO[\-\s.](\d{3})[\-\s.]([A-Z]{2,3})"),
             field=OCRField.text_annotations,
-            lowercase=False,
             processing_func=process_es_bio_label_code,
         ),
     ],
     "fr:ab-agriculture-biologique": [
         OCRRegex(
-            re.compile(r"certifi[ée] ab[\s.,)]"),
+            re.compile(r"certifi[ée] ab[\s.,)]", re.I),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
         ),
     ],
     "en:pgi": [
         OCRRegex(
             re.compile(
-                r"indication g[ée]ographique prot[eé]g[eé]e|Indicazione geografica protetta|geschützte geografische angabe"
+                r"indication g[ée]ographique prot[eé]g[eé]e|Indicazione geografica protetta|geschützte geografische angabe",
+                re.I,
             ),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
         ),
         OCRRegex(
             re.compile(r"(?<!\w)(?:IGP|BGA|PGI)(?!\w)"),
             field=OCRField.full_text_contiguous,
-            lowercase=False,
         ),
     ],
     "fr:label-rouge": [
         OCRRegex(
-            re.compile(r"d[ée]cret du 0?5[./]01[./]07"),
+            re.compile(r"d[ée]cret du 0?5[./]01[./]07", re.I),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
         ),
         OCRRegex(
-            re.compile(r"(?<!\w)homologation(?: n°?)? ?la ?\d{2}\/\d{2}(?!\w)"),
+            re.compile(r"(?<!\w)homologation(?: n°?)? ?la ?\d{2}\/\d{2}(?!\w)", re.I),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
         ),
     ],
     "en:pdo": [
         OCRRegex(
             re.compile(r"(?<!\w)(?:PDO|AOP|DOP)(?!\w)"),
             field=OCRField.full_text_contiguous,
-            lowercase=False,
         ),
         OCRRegex(
-            re.compile(r"appellation d'origine prot[eé]g[eé]e"),
+            re.compile(r"appellation d'origine prot[eé]g[eé]e", re.I),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
         ),
     ],
     "fr:aoc": [
         OCRRegex(
-            re.compile(r"(?<!\w)(?:AOC)(?!\w)"),
-            field=OCRField.full_text_contiguous,
-            lowercase=False,
+            re.compile(r"(?<!\w)(?:AOC)(?!\w)"), field=OCRField.full_text_contiguous
         ),
     ],
     "en:nutriscore": [
-        OCRRegex(
-            re.compile(r"NUTRI-SCORE"),
-            field=OCRField.full_text,
-            lowercase=False,
-        ),
+        OCRRegex(re.compile(r"NUTRI-SCORE"), field=OCRField.full_text),
     ],
     "en:eu-non-eu-agriculture": [
         OCRRegex(
             re.compile(
-                r"agriculture ue\s?/\s?non\s?(?:-\s?)?ue|eu\s?/\s?non\s?(?:-\s?)?eu agriculture"
+                r"agriculture ue\s?/\s?non\s?(?:-\s?)?ue|eu\s?/\s?non\s?(?:-\s?)?eu agriculture",
+                re.I,
             ),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
         ),
     ],
     "en:eu-agriculture": [
         # The negative lookafter/lookbehind forbid matching "agriculture ue/non ue"
         OCRRegex(
-            re.compile(r"agriculture ue(?!\s?/)|(?<!-)\s?eu agriculture"),
+            re.compile(r"agriculture ue(?!\s?/)|(?<!-)\s?eu agriculture", re.I),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
         ),
     ],
     "en:non-eu-agriculture": [
         OCRRegex(
-            re.compile(r"agriculture non\s?(?:-\s?)?ue|non\s?(?:-\s?)?eu agriculture"),
+            re.compile(
+                r"agriculture non\s?(?:-\s?)?ue|non\s?(?:-\s?)?eu agriculture", re.I
+            ),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
         ),
     ],
     "en:no-preservatives": [
         OCRRegex(
             re.compile(
-                r"senza conservanti(?! arti)|без консервантов|conserveermiddelvrij|(?<!\w)(?:sans|ni) conservateur(?!s? arti)|fără conservanți|no preservative|sin conservante(?!s? arti)|ohne konservierungsstoffe"
+                r"senza conservanti(?! arti)|без консервантов|conserveermiddelvrij|(?<!\w)(?:sans|ni) conservateur(?!s? arti)|fără conservanți|no preservative|sin conservante(?!s? arti)|ohne konservierungsstoffe",
+                re.I,
             ),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
         ),
     ],
     "en:no-flavors": [
         OCRRegex(
             re.compile(
-                r"без ароматизаторов|senza aromi|zonder toegevoegde smaakstoffen|(?<!\w)(?:sans|ni) ar[ôo]mes? ajout[ée]s|sin aromas?|ohne zusatz von aromen|no flavors?"
+                r"без ароматизаторов|senza aromi|zonder toegevoegde smaakstoffen|(?<!\w)(?:sans|ni) ar[ôo]mes? ajout[ée]s|sin aromas?|ohne zusatz von aromen|no flavors?",
+                re.I,
             ),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
         ),
     ],
     "en:no-artificial-flavors": [
         OCRRegex(
             re.compile(
-                r"без искусственных ароматизаторов|ohne künstliche aromen|sin aromas? artificiales?|vrij van kunstmatige smaakstoffen|(?<!\w)(?:sans|ni) ar[ôo]mes? artificiels?|no artificial flavors?"
+                r"без искусственных ароматизаторов|ohne künstliche aromen|sin aromas? artificiales?|vrij van kunstmatige smaakstoffen|(?<!\w)(?:sans|ni) ar[ôo]mes? artificiels?|no artificial flavors?",
+                re.I,
             ),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
         ),
     ],
     "en:no-colorings": [
         OCRRegex(
             re.compile(
-                r"no colorings?|no colourants?|ohne farbstoffzusatz|(?<!\w)(?:sans|ni) colorants?|zonder kleurstoffen|sin colorantes?|без красителей|senza coloranti"
+                r"no colorings?|no colourants?|ohne farbstoffzusatz|(?<!\w)(?:sans|ni) colorants?|zonder kleurstoffen|sin colorantes?|без красителей|senza coloranti",
+                re.I,
             ),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
         ),
     ],
     "en:no-additives": [
         OCRRegex(
             re.compile(
-                r"zonder toevoegingen|sin aditivos(?! arti)|(?<!\w)(?:sans|ni) additif(?!s? arti)|ohne zusätze|no additives?"
+                r"zonder toevoegingen|sin aditivos(?! arti)|(?<!\w)(?:sans|ni) additif(?!s? arti)|ohne zusätze|no additives?",
+                re.I,
             ),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
         ),
     ],
 }

--- a/robotoff/prediction/ocr/label.py
+++ b/robotoff/prediction/ocr/label.py
@@ -54,13 +54,13 @@ LABELS_REGEX = {
             re.compile(
                 r"(?<![a-zA-Z])([A-Z]{2})[\-\s.](BIO|ÖKO|OKO|EKO|ØKO|ORG|Bio)[\-\s.](\d{2,3})"
             ),
-            field=OCRField.text_annotations,
+            field=OCRField.full_text,
             processing_func=process_eu_bio_label_code,
         ),
         # Spain specific regex
         OCRRegex(
             re.compile(r"(?<![a-zA-Z])ES[\-\s.]ECO[\-\s.](\d{3})[\-\s.]([A-Z]{2,3})"),
-            field=OCRField.text_annotations,
+            field=OCRField.full_text,
             processing_func=process_es_bio_label_code,
         ),
     ],

--- a/robotoff/prediction/ocr/location.py
+++ b/robotoff/prediction/ocr/location.py
@@ -12,7 +12,7 @@ from robotoff.prediction.types import Prediction
 from robotoff.types import PredictionType
 from robotoff.utils import get_logger
 from robotoff.utils.cache import CachedStore
-from robotoff.utils.text import strip_accents_ascii
+from robotoff.utils.text import strip_accents_v1
 
 from .dataclass import OCRResult
 
@@ -186,7 +186,7 @@ class AddressExtractor:
     @staticmethod
     def normalize_text(text: str) -> str:
         text = text.lower()
-        text = strip_accents_ascii(text)
+        text = strip_accents_v1(text)
         return text.replace("'", " ").replace("-", " ")
 
     def find_city_names(self, text: str) -> list[tuple[City, int, int]]:

--- a/robotoff/prediction/ocr/location.py
+++ b/robotoff/prediction/ocr/location.py
@@ -175,13 +175,7 @@ class AddressExtractor:
         Returns:
             str: The text extracted and prepared.
         """
-        text = ocr_result.get_full_text()
-        if text is None:
-            # Using `OCRResult.text_annotations` directly instead of
-            # `OCRResult.get_text_annotations()` because the latter contains
-            # the text duplicated
-            text = ocr_result.text_annotations[0].text
-        return text
+        return ocr_result.get_text()
 
     @staticmethod
     def normalize_text(text: str) -> str:

--- a/robotoff/prediction/ocr/location.py
+++ b/robotoff/prediction/ocr/location.py
@@ -175,7 +175,13 @@ class AddressExtractor:
         Returns:
             str: The text extracted and prepared.
         """
-        return ocr_result.get_text()
+        text = ocr_result.get_full_text()
+        if text is None:
+            # Using `OCRResult.text_annotations` directly instead of
+            # `OCRResult.get_text_annotations()` because the latter contains
+            # the text duplicated
+            text = ocr_result.text_annotations[0].text
+        return text
 
     @staticmethod
     def normalize_text(text: str) -> str:

--- a/robotoff/prediction/ocr/nutrient.py
+++ b/robotoff/prediction/ocr/nutrient.py
@@ -121,7 +121,8 @@ def generate_nutrient_regex(
     return re.compile(
         r"(?<!\w)({}) ?(?:[:-] ?)?([0-9]+[,.]?[0-9]*) ?({})(?!\w)".format(
             nutrient_names_str, units_str
-        )
+        ),
+        re.I,
     )
 
 
@@ -130,14 +131,13 @@ def generate_nutrient_mention_regex(nutrient_mentions: list[NutrientMentionType]
         r"(?P<{}>{})".format("{}_{}".format("_".join(lang), i), name)
         for i, (name, lang) in enumerate(nutrient_mentions)
     )
-    return re.compile(r"(?<!\w){}(?!\w)".format(sub_re))
+    return re.compile(r"(?<!\w){}(?!\w)".format(sub_re), re.I)
 
 
 NUTRIENT_VALUES_REGEX = {
     nutrient: OCRRegex(
         generate_nutrient_regex(NUTRIENT_MENTION[nutrient], units),
         field=OCRField.full_text_contiguous,
-        lowercase=True,
     )
     for nutrient, units in NUTRIENT_UNITS.items()
 }
@@ -146,7 +146,6 @@ NUTRIENT_MENTIONS_REGEX: dict[str, OCRRegex] = {
     nutrient: OCRRegex(
         generate_nutrient_mention_regex(NUTRIENT_MENTION[nutrient]),
         field=OCRField.full_text_contiguous,
-        lowercase=True,
     )
     for nutrient in NUTRIENT_MENTION
 }

--- a/robotoff/prediction/ocr/nutrient.py
+++ b/robotoff/prediction/ocr/nutrient.py
@@ -4,7 +4,7 @@ from typing import Union
 from robotoff.prediction.types import Prediction
 from robotoff.types import JSONType, PredictionType
 
-from .dataclass import OCRRegex, OCRResult, get_text
+from .dataclass import OCRField, OCRRegex, OCRResult, get_text
 
 EXTRACTOR_VERSION = "2"
 
@@ -137,12 +137,16 @@ def generate_nutrient_mention_regex(nutrient_mentions: list[NutrientMentionType]
 NUTRIENT_VALUES_REGEX = {
     nutrient: OCRRegex(
         generate_nutrient_regex(NUTRIENT_MENTION[nutrient], units),
+        field=OCRField.full_text_contiguous,
     )
     for nutrient, units in NUTRIENT_UNITS.items()
 }
 
 NUTRIENT_MENTIONS_REGEX: dict[str, OCRRegex] = {
-    nutrient: OCRRegex(generate_nutrient_mention_regex(NUTRIENT_MENTION[nutrient]))
+    nutrient: OCRRegex(
+        generate_nutrient_mention_regex(NUTRIENT_MENTION[nutrient]),
+        field=OCRField.full_text_contiguous,
+    )
     for nutrient in NUTRIENT_MENTION
 }
 
@@ -151,7 +155,7 @@ def find_nutrient_values(content: Union[OCRResult, str]) -> list[Prediction]:
     nutrients: JSONType = {}
 
     for regex_code, ocr_regex in NUTRIENT_VALUES_REGEX.items():
-        text = get_text(content)
+        text = get_text(content, ocr_regex)
 
         if not text:
             continue
@@ -184,7 +188,7 @@ def find_nutrient_mentions(content: Union[OCRResult, str]) -> list[Prediction]:
     nutrients: JSONType = {}
 
     for regex_code, ocr_regex in NUTRIENT_MENTIONS_REGEX.items():
-        text = get_text(content)
+        text = get_text(content, ocr_regex)
 
         if not text:
             continue

--- a/robotoff/prediction/ocr/nutrient.py
+++ b/robotoff/prediction/ocr/nutrient.py
@@ -4,7 +4,7 @@ from typing import Union
 from robotoff.prediction.types import Prediction
 from robotoff.types import JSONType, PredictionType
 
-from .dataclass import OCRField, OCRRegex, OCRResult, get_text
+from .dataclass import OCRRegex, OCRResult, get_text
 
 EXTRACTOR_VERSION = "2"
 
@@ -137,16 +137,12 @@ def generate_nutrient_mention_regex(nutrient_mentions: list[NutrientMentionType]
 NUTRIENT_VALUES_REGEX = {
     nutrient: OCRRegex(
         generate_nutrient_regex(NUTRIENT_MENTION[nutrient], units),
-        field=OCRField.full_text_contiguous,
     )
     for nutrient, units in NUTRIENT_UNITS.items()
 }
 
 NUTRIENT_MENTIONS_REGEX: dict[str, OCRRegex] = {
-    nutrient: OCRRegex(
-        generate_nutrient_mention_regex(NUTRIENT_MENTION[nutrient]),
-        field=OCRField.full_text_contiguous,
-    )
+    nutrient: OCRRegex(generate_nutrient_mention_regex(NUTRIENT_MENTION[nutrient]))
     for nutrient in NUTRIENT_MENTION
 }
 
@@ -155,7 +151,7 @@ def find_nutrient_values(content: Union[OCRResult, str]) -> list[Prediction]:
     nutrients: JSONType = {}
 
     for regex_code, ocr_regex in NUTRIENT_VALUES_REGEX.items():
-        text = get_text(content, ocr_regex)
+        text = get_text(content)
 
         if not text:
             continue
@@ -188,7 +184,7 @@ def find_nutrient_mentions(content: Union[OCRResult, str]) -> list[Prediction]:
     nutrients: JSONType = {}
 
     for regex_code, ocr_regex in NUTRIENT_MENTIONS_REGEX.items():
-        text = get_text(content, ocr_regex)
+        text = get_text(content)
 
         if not text:
             continue

--- a/robotoff/prediction/ocr/packager_code.py
+++ b/robotoff/prediction/ocr/packager_code.py
@@ -78,37 +78,35 @@ USDA_CODE_KEYWORD_PROCESSOR_STORE = CachedStore(
 PACKAGER_CODE = {
     "fr_emb": [
         OCRRegex(
-            re.compile(r"emb ?(\d ?\d ?\d ?\d ?\d) ?([a-z])?(?![a-z0-9])"),
+            re.compile(r"emb ?(\d ?\d ?\d ?\d ?\d) ?([a-z])?(?![a-z0-9])", re.I),
             field=OCRField.text_annotations,
-            lowercase=True,
             processing_func=process_fr_emb_match,
         ),
     ],
     "fsc": [
         OCRRegex(
-            re.compile(r"fsc.? ?(c\d{6})"),
+            re.compile(r"fsc.? ?(c\d{6})", re.I),
             field=OCRField.text_annotations,
-            lowercase=True,
             processing_func=process_fsc_match,
         ),
     ],
     "eu_fr": [
         OCRRegex(
             re.compile(
-                r"fr (\d{2,3}|2[ab])[\-\s.](\d{3})[\-\s.](\d{3}) (ce|ec)(?![a-z0-9])"
+                r"fr (\d{2,3}|2[ab])[\-\s.](\d{3})[\-\s.](\d{3}) (ce|ec)(?![a-z0-9])",
+                re.I,
             ),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
             processing_func=process_fr_packaging_match,
         ),
     ],
     "eu_de": [
         OCRRegex(
             re.compile(
-                r"de (bb|be|bw|by|hb|he|hh|mv|ni|nw|rp|sh|sl|sn|st|th)[\-\s.](\d{1,5})[\-\s.] ?(eg|ec)(?![a-z0-9])"
+                r"de (bb|be|bw|by|hb|he|hh|mv|ni|nw|rp|sh|sl|sn|st|th)[\-\s.](\d{1,5})[\-\s.] ?(eg|ec)(?![a-z0-9])",
+                re.I,
             ),
             field=OCRField.full_text_contiguous,
-            lowercase=True,
             processing_func=process_de_packaging_match,
         ),
     ],
@@ -116,14 +114,12 @@ PACKAGER_CODE = {
         OCRRegex(
             re.compile(r"(?<!\w)RSPO-\d{7}(?!\d)"),
             field=OCRField.full_text_contiguous,
-            lowercase=False,
         ),
     ],
     "fr_gluten": [
         OCRRegex(
             re.compile(r"FR-\d{3}-\d{3}"),
             field=OCRField.full_text_contiguous,
-            lowercase=False,
         ),
     ],
     # Temporarily disable USDA extraction until the overmatching bug is fixed
@@ -132,14 +128,12 @@ PACKAGER_CODE = {
     #     OCRRegex(
     #         re.compile(r"EST\.*\s*\d{1,5}[A-Z]{0,3}\.*"),
     #         field=OCRField.full_text_contiguous,
-    #         lowercase=False,
     #         processing_func=process_USDA_match_to_flashtext,
     #     ),
     #     # To match the USDA like "V34626"
     #     OCRRegex(
     #         re.compile(r"[A-Z]\d{1,5}[A-Z]?"),
     #         field=OCRField.full_text_contiguous,
-    #         lowercase=False,
     #         processing_func=process_USDA_match_to_flashtext,
     #     ),
     # ],
@@ -151,7 +145,7 @@ def find_packager_codes_regex(ocr_result: Union[OCRResult, str]) -> list[Predict
 
     for regex_code, regex_list in PACKAGER_CODE.items():
         for ocr_regex in regex_list:
-            text = get_text(ocr_result, ocr_regex, ocr_regex.lowercase)
+            text = get_text(ocr_result, ocr_regex)
 
             if not text:
                 continue

--- a/robotoff/prediction/ocr/packager_code.py
+++ b/robotoff/prediction/ocr/packager_code.py
@@ -79,14 +79,14 @@ PACKAGER_CODE = {
     "fr_emb": [
         OCRRegex(
             re.compile(r"emb ?(\d ?\d ?\d ?\d ?\d) ?([a-z])?(?![a-z0-9])", re.I),
-            field=OCRField.text_annotations,
+            field=OCRField.full_text,
             processing_func=process_fr_emb_match,
         ),
     ],
     "fsc": [
         OCRRegex(
             re.compile(r"fsc.? ?(c\d{6})", re.I),
-            field=OCRField.text_annotations,
+            field=OCRField.full_text,
             processing_func=process_fsc_match,
         ),
     ],

--- a/robotoff/prediction/ocr/packager_code.py
+++ b/robotoff/prediction/ocr/packager_code.py
@@ -9,7 +9,7 @@ from robotoff.types import PredictionType
 from robotoff.utils import text_file_iter
 from robotoff.utils.cache import CachedStore
 
-from .dataclass import OCRField, OCRRegex, OCRResult, get_text
+from .dataclass import OCRRegex, OCRResult, get_text
 from .utils import generate_keyword_processor
 
 
@@ -79,14 +79,12 @@ PACKAGER_CODE = {
     "fr_emb": [
         OCRRegex(
             re.compile(r"emb ?(\d ?\d ?\d ?\d ?\d) ?([a-z])?(?![a-z0-9])", re.I),
-            field=OCRField.text_annotations,
             processing_func=process_fr_emb_match,
         ),
     ],
     "fsc": [
         OCRRegex(
             re.compile(r"fsc.? ?(c\d{6})", re.I),
-            field=OCRField.text_annotations,
             processing_func=process_fsc_match,
         ),
     ],
@@ -96,7 +94,6 @@ PACKAGER_CODE = {
                 r"fr (\d{2,3}|2[ab])[\-\s.](\d{3})[\-\s.](\d{3}) (ce|ec)(?![a-z0-9])",
                 re.I,
             ),
-            field=OCRField.full_text_contiguous,
             processing_func=process_fr_packaging_match,
         ),
     ],
@@ -106,21 +103,14 @@ PACKAGER_CODE = {
                 r"de (bb|be|bw|by|hb|he|hh|mv|ni|nw|rp|sh|sl|sn|st|th)[\-\s.](\d{1,5})[\-\s.] ?(eg|ec)(?![a-z0-9])",
                 re.I,
             ),
-            field=OCRField.full_text_contiguous,
             processing_func=process_de_packaging_match,
         ),
     ],
     "rspo": [
-        OCRRegex(
-            re.compile(r"(?<!\w)RSPO-\d{7}(?!\d)"),
-            field=OCRField.full_text_contiguous,
-        ),
+        OCRRegex(re.compile(r"(?<!\w)RSPO-\d{7}(?!\d)")),
     ],
     "fr_gluten": [
-        OCRRegex(
-            re.compile(r"FR-\d{3}-\d{3}"),
-            field=OCRField.full_text_contiguous,
-        ),
+        OCRRegex(re.compile(r"FR-\d{3}-\d{3}")),
     ],
     # Temporarily disable USDA extraction until the overmatching bug is fixed
     # "USDA": [
@@ -145,7 +135,7 @@ def find_packager_codes_regex(ocr_result: Union[OCRResult, str]) -> list[Predict
 
     for regex_code, regex_list in PACKAGER_CODE.items():
         for ocr_regex in regex_list:
-            text = get_text(ocr_result, ocr_regex)
+            text = get_text(ocr_result)
 
             if not text:
                 continue

--- a/robotoff/prediction/ocr/product_weight.py
+++ b/robotoff/prediction/ocr/product_weight.py
@@ -8,7 +8,7 @@ from robotoff.prediction.types import Prediction
 from robotoff.types import PredictionType
 from robotoff.utils import get_logger
 
-from .dataclass import OCRRegex, OCRResult, get_text
+from .dataclass import OCRField, OCRRegex, OCRResult, get_text
 
 logger = get_logger(__name__)
 
@@ -205,6 +205,7 @@ PRODUCT_WEIGHT_REGEX: dict[str, OCRRegex] = {
             r"(?<![a-z])(poids|poids net [aà] l'emballage|poids net|poids net égoutté|masse nette|volume net total|net weight|net wt\.?|peso neto|peso liquido|netto[ -]?gewicht)\s?:?\s?([0-9]+[,.]?[0-9]*)\s?(fl oz|dle?|cle?|mge?|mle?|lbs|oz|ge?|kge?|le?)(?![a-z])",
             re.I,
         ),
+        field=OCRField.full_text_contiguous,
         processing_func=functools.partial(
             process_product_weight, prompt=True, automatic_processing=True
         ),
@@ -215,6 +216,7 @@ PRODUCT_WEIGHT_REGEX: dict[str, OCRRegex] = {
             r"(?<![a-z])([0-9]+[,.]?[0-9]*)\s?(fl oz|dle?|cle?|mge?|mle?|lbs|oz|ge?|kge?|le?)\s(net)(?![a-z])",
             re.I,
         ),
+        field=OCRField.full_text_contiguous,
         processing_func=functools.partial(
             process_product_weight,
             prompt=True,
@@ -228,6 +230,7 @@ PRODUCT_WEIGHT_REGEX: dict[str, OCRRegex] = {
             r"(?<![a-z])(\d+)\s?x\s?([0-9]+[,.]?[0-9]*)\s?(fl oz|dle?|cle?|mge?|mle?|lbs|oz|ge?|kge?|le?)(?![a-z])",
             re.I,
         ),
+        field=OCRField.full_text_contiguous,
         processing_func=process_multi_packaging,
         priority=2,
     ),
@@ -235,6 +238,7 @@ PRODUCT_WEIGHT_REGEX: dict[str, OCRRegex] = {
         re.compile(
             r"(?<![a-z])([0-9]+[,.]?[0-9]*)\s?(dle|cle|mge|mle|ge|kge)(?![a-z])", re.I
         ),
+        field=OCRField.full_text_contiguous,
         processing_func=functools.partial(
             process_product_weight, prompt=False, automatic_processing=False
         ),
@@ -247,7 +251,7 @@ def find_product_weight(content: Union[OCRResult, str]) -> list[Prediction]:
     results = []
 
     for type_, ocr_regex in PRODUCT_WEIGHT_REGEX.items():
-        text = get_text(content)
+        text = get_text(content, ocr_regex)
 
         if not text:
             continue

--- a/robotoff/prediction/ocr/product_weight.py
+++ b/robotoff/prediction/ocr/product_weight.py
@@ -128,6 +128,7 @@ def process_product_weight(
         value = match.group(1)
         unit = match.group(2)
 
+    unit = unit.lower()
     if unit in ("dle", "cle", "mge", "mle", "ge", "kge", "le"):
         # When the e letter often comes after the weight unit, the
         # space is often not detected

--- a/robotoff/prediction/ocr/product_weight.py
+++ b/robotoff/prediction/ocr/product_weight.py
@@ -8,7 +8,7 @@ from robotoff.prediction.types import Prediction
 from robotoff.types import PredictionType
 from robotoff.utils import get_logger
 
-from .dataclass import OCRField, OCRRegex, OCRResult, get_text
+from .dataclass import OCRRegex, OCRResult, get_text
 
 logger = get_logger(__name__)
 
@@ -204,7 +204,6 @@ PRODUCT_WEIGHT_REGEX: dict[str, OCRRegex] = {
             r"(?<![a-z])(poids|poids net [aà] l'emballage|poids net|poids net égoutté|masse nette|volume net total|net weight|net wt\.?|peso neto|peso liquido|netto[ -]?gewicht)\s?:?\s?([0-9]+[,.]?[0-9]*)\s?(fl oz|dle?|cle?|mge?|mle?|lbs|oz|ge?|kge?|le?)(?![a-z])",
             re.I,
         ),
-        field=OCRField.full_text_contiguous,
         processing_func=functools.partial(
             process_product_weight, prompt=True, automatic_processing=True
         ),
@@ -215,7 +214,6 @@ PRODUCT_WEIGHT_REGEX: dict[str, OCRRegex] = {
             r"(?<![a-z])([0-9]+[,.]?[0-9]*)\s?(fl oz|dle?|cle?|mge?|mle?|lbs|oz|ge?|kge?|le?)\s(net)(?![a-z])",
             re.I,
         ),
-        field=OCRField.full_text_contiguous,
         processing_func=functools.partial(
             process_product_weight,
             prompt=True,
@@ -229,7 +227,6 @@ PRODUCT_WEIGHT_REGEX: dict[str, OCRRegex] = {
             r"(?<![a-z])(\d+)\s?x\s?([0-9]+[,.]?[0-9]*)\s?(fl oz|dle?|cle?|mge?|mle?|lbs|oz|ge?|kge?|le?)(?![a-z])",
             re.I,
         ),
-        field=OCRField.full_text_contiguous,
         processing_func=process_multi_packaging,
         priority=2,
     ),
@@ -237,7 +234,6 @@ PRODUCT_WEIGHT_REGEX: dict[str, OCRRegex] = {
         re.compile(
             r"(?<![a-z])([0-9]+[,.]?[0-9]*)\s?(dle|cle|mge|mle|ge|kge)(?![a-z])", re.I
         ),
-        field=OCRField.full_text_contiguous,
         processing_func=functools.partial(
             process_product_weight, prompt=False, automatic_processing=False
         ),
@@ -250,7 +246,7 @@ def find_product_weight(content: Union[OCRResult, str]) -> list[Prediction]:
     results = []
 
     for type_, ocr_regex in PRODUCT_WEIGHT_REGEX.items():
-        text = get_text(content, ocr_regex)
+        text = get_text(content)
 
         if not text:
             continue

--- a/robotoff/prediction/ocr/product_weight.py
+++ b/robotoff/prediction/ocr/product_weight.py
@@ -201,10 +201,10 @@ def process_multi_packaging(match) -> Optional[dict]:
 PRODUCT_WEIGHT_REGEX: dict[str, OCRRegex] = {
     "with_mention": OCRRegex(
         re.compile(
-            r"(?<![a-z])(poids|poids net [aà] l'emballage|poids net|poids net égoutté|masse nette|volume net total|net weight|net wt\.?|peso neto|peso liquido|netto[ -]?gewicht)\s?:?\s?([0-9]+[,.]?[0-9]*)\s?(fl oz|dle?|cle?|mge?|mle?|lbs|oz|ge?|kge?|le?)(?![a-z])"
+            r"(?<![a-z])(poids|poids net [aà] l'emballage|poids net|poids net égoutté|masse nette|volume net total|net weight|net wt\.?|peso neto|peso liquido|netto[ -]?gewicht)\s?:?\s?([0-9]+[,.]?[0-9]*)\s?(fl oz|dle?|cle?|mge?|mle?|lbs|oz|ge?|kge?|le?)(?![a-z])",
+            re.I,
         ),
         field=OCRField.full_text_contiguous,
-        lowercase=True,
         processing_func=functools.partial(
             process_product_weight, prompt=True, automatic_processing=True
         ),
@@ -212,10 +212,10 @@ PRODUCT_WEIGHT_REGEX: dict[str, OCRRegex] = {
     ),
     "with_ending_mention": OCRRegex(
         re.compile(
-            r"(?<![a-z])([0-9]+[,.]?[0-9]*)\s?(fl oz|dle?|cle?|mge?|mle?|lbs|oz|ge?|kge?|le?)\s(net)(?![a-z])"
+            r"(?<![a-z])([0-9]+[,.]?[0-9]*)\s?(fl oz|dle?|cle?|mge?|mle?|lbs|oz|ge?|kge?|le?)\s(net)(?![a-z])",
+            re.I,
         ),
         field=OCRField.full_text_contiguous,
-        lowercase=True,
         processing_func=functools.partial(
             process_product_weight,
             prompt=True,
@@ -226,19 +226,18 @@ PRODUCT_WEIGHT_REGEX: dict[str, OCRRegex] = {
     ),
     "multi_packaging": OCRRegex(
         re.compile(
-            r"(?<![a-z])(\d+)\s?x\s?([0-9]+[,.]?[0-9]*)\s?(fl oz|dle?|cle?|mge?|mle?|lbs|oz|ge?|kge?|le?)(?![a-z])"
+            r"(?<![a-z])(\d+)\s?x\s?([0-9]+[,.]?[0-9]*)\s?(fl oz|dle?|cle?|mge?|mle?|lbs|oz|ge?|kge?|le?)(?![a-z])",
+            re.I,
         ),
         field=OCRField.full_text_contiguous,
-        lowercase=True,
         processing_func=process_multi_packaging,
         priority=2,
     ),
     "no_mention": OCRRegex(
         re.compile(
-            r"(?<![a-z])([0-9]+[,.]?[0-9]*)\s?(dle|cle|mge|mle|ge|kge)(?![a-z])"
+            r"(?<![a-z])([0-9]+[,.]?[0-9]*)\s?(dle|cle|mge|mle|ge|kge)(?![a-z])", re.I
         ),
         field=OCRField.full_text_contiguous,
-        lowercase=True,
         processing_func=functools.partial(
             process_product_weight, prompt=False, automatic_processing=False
         ),

--- a/robotoff/prediction/ocr/store.py
+++ b/robotoff/prediction/ocr/store.py
@@ -6,7 +6,7 @@ from robotoff.prediction.types import Prediction
 from robotoff.types import PredictionType
 from robotoff.utils import text_file_iter
 
-from .dataclass import OCRField, OCRRegex, OCRResult, get_text
+from .dataclass import OCRRegex, OCRResult, get_text
 
 
 def get_store_tag(store: str) -> str:
@@ -43,15 +43,13 @@ STORE_REGEX_STR = "|".join(
     r"((?<!\w){}(?!\w))".format(pattern) for _, pattern in SORTED_STORES
 )
 NOTIFY_STORES: set[str] = set(text_file_iter(settings.OCR_STORES_NOTIFY_DATA_PATH))
-STORE_REGEX = OCRRegex(
-    re.compile(STORE_REGEX_STR, re.I), field=OCRField.full_text_contiguous
-)
+STORE_REGEX = OCRRegex(re.compile(STORE_REGEX_STR, re.I))
 
 
 def find_stores(content: Union[OCRResult, str]) -> list[Prediction]:
     results = []
 
-    text = get_text(content, STORE_REGEX)
+    text = get_text(content)
 
     if not text:
         return []

--- a/robotoff/prediction/ocr/store.py
+++ b/robotoff/prediction/ocr/store.py
@@ -6,7 +6,7 @@ from robotoff.prediction.types import Prediction
 from robotoff.types import PredictionType
 from robotoff.utils import text_file_iter
 
-from .dataclass import OCRRegex, OCRResult, get_text
+from .dataclass import OCRField, OCRRegex, OCRResult, get_text
 
 
 def get_store_tag(store: str) -> str:
@@ -43,13 +43,15 @@ STORE_REGEX_STR = "|".join(
     r"((?<!\w){}(?!\w))".format(pattern) for _, pattern in SORTED_STORES
 )
 NOTIFY_STORES: set[str] = set(text_file_iter(settings.OCR_STORES_NOTIFY_DATA_PATH))
-STORE_REGEX = OCRRegex(re.compile(STORE_REGEX_STR, re.I))
+STORE_REGEX = OCRRegex(
+    re.compile(STORE_REGEX_STR, re.I), field=OCRField.full_text_contiguous
+)
 
 
 def find_stores(content: Union[OCRResult, str]) -> list[Prediction]:
     results = []
 
-    text = get_text(content)
+    text = get_text(content, STORE_REGEX)
 
     if not text:
         return []

--- a/robotoff/prediction/ocr/store.py
+++ b/robotoff/prediction/ocr/store.py
@@ -6,7 +6,7 @@ from robotoff.prediction.types import Prediction
 from robotoff.types import PredictionType
 from robotoff.utils import text_file_iter
 
-from .dataclass import OCRField, OCRRegex, OCRResult, get_text
+from .dataclass import OCRField, OCRRegex, OCRResult, get_match_bounding_box, get_text
 
 
 def get_store_tag(store: str) -> str:
@@ -62,12 +62,20 @@ def find_stores(content: Union[OCRResult, str]) -> list[Prediction]:
         for idx, match_str in enumerate(groups):
             if match_str is not None:
                 store, _ = SORTED_STORES[idx]
+                data = {"text": match_str, "notify": store in NOTIFY_STORES}
+                if (
+                    bounding_box := get_match_bounding_box(
+                        content, match.start(), match.end()
+                    )
+                ) is not None:
+                    data["bounding_box_absolute"] = bounding_box
+
                 results.append(
                     Prediction(
                         type=PredictionType.store,
                         value=store,
                         value_tag=get_store_tag(store),
-                        data={"text": match_str, "notify": store in NOTIFY_STORES},
+                        data=data,
                         predictor="regex",
                     )
                 )

--- a/robotoff/prediction/ocr/store.py
+++ b/robotoff/prediction/ocr/store.py
@@ -44,7 +44,7 @@ STORE_REGEX_STR = "|".join(
 )
 NOTIFY_STORES: set[str] = set(text_file_iter(settings.OCR_STORES_NOTIFY_DATA_PATH))
 STORE_REGEX = OCRRegex(
-    re.compile(STORE_REGEX_STR), field=OCRField.full_text_contiguous, lowercase=True
+    re.compile(STORE_REGEX_STR, re.I), field=OCRField.full_text_contiguous
 )
 
 

--- a/robotoff/prediction/ocr/trace.py
+++ b/robotoff/prediction/ocr/trace.py
@@ -7,7 +7,7 @@ from robotoff.types import PredictionType
 from robotoff.utils import text_file_iter
 from robotoff.utils.cache import CachedStore
 
-from .dataclass import OCRField, OCRRegex, OCRResult, get_text
+from .dataclass import OCRRegex, OCRResult, get_text
 from .utils import generate_keyword_processor
 
 
@@ -23,7 +23,6 @@ TRACES_REGEX = OCRRegex(
         r"(?:possibilit[ée] de traces|conditionné dans un atelier qui manipule|peut contenir(?: des traces)?|traces? [ée]ventuelles? d[e']|traces? d[e']|may contain)",
         re.I,
     ),
-    field=OCRField.full_text_contiguous,
 )
 
 TRACE_KEYWORD_PROCESSOR_STORE = CachedStore(
@@ -34,7 +33,7 @@ TRACE_KEYWORD_PROCESSOR_STORE = CachedStore(
 def find_traces(content: Union[OCRResult, str]) -> list[Prediction]:
     predictions = []
 
-    text = get_text(content, TRACES_REGEX)
+    text = get_text(content)
 
     if not text:
         return []

--- a/robotoff/prediction/ocr/trace.py
+++ b/robotoff/prediction/ocr/trace.py
@@ -20,10 +20,10 @@ def generate_trace_keyword_processor(labels: Optional[list[str]] = None):
 
 TRACES_REGEX = OCRRegex(
     re.compile(
-        r"(?:possibilit[ée] de traces|conditionné dans un atelier qui manipule|peut contenir(?: des traces)?|traces? [ée]ventuelles? d[e']|traces? d[e']|may contain)"
+        r"(?:possibilit[ée] de traces|conditionné dans un atelier qui manipule|peut contenir(?: des traces)?|traces? [ée]ventuelles? d[e']|traces? d[e']|may contain)",
+        re.I,
     ),
     field=OCRField.full_text_contiguous,
-    lowercase=True,
 )
 
 TRACE_KEYWORD_PROCESSOR_STORE = CachedStore(

--- a/robotoff/prediction/ocr/trace.py
+++ b/robotoff/prediction/ocr/trace.py
@@ -7,7 +7,7 @@ from robotoff.types import PredictionType
 from robotoff.utils import text_file_iter
 from robotoff.utils.cache import CachedStore
 
-from .dataclass import OCRRegex, OCRResult, get_text
+from .dataclass import OCRField, OCRRegex, OCRResult, get_text
 from .utils import generate_keyword_processor
 
 
@@ -23,6 +23,7 @@ TRACES_REGEX = OCRRegex(
         r"(?:possibilit[ée] de traces|conditionné dans un atelier qui manipule|peut contenir(?: des traces)?|traces? [ée]ventuelles? d[e']|traces? d[e']|may contain)",
         re.I,
     ),
+    field=OCRField.full_text_contiguous,
 )
 
 TRACE_KEYWORD_PROCESSOR_STORE = CachedStore(
@@ -33,7 +34,7 @@ TRACE_KEYWORD_PROCESSOR_STORE = CachedStore(
 def find_traces(content: Union[OCRResult, str]) -> list[Prediction]:
     predictions = []
 
-    text = get_text(content)
+    text = get_text(content, TRACES_REGEX)
 
     if not text:
         return []

--- a/robotoff/prediction/ocr/trace.py
+++ b/robotoff/prediction/ocr/trace.py
@@ -7,7 +7,7 @@ from robotoff.types import PredictionType
 from robotoff.utils import text_file_iter
 from robotoff.utils.cache import CachedStore
 
-from .dataclass import OCRField, OCRRegex, OCRResult, get_text
+from .dataclass import OCRField, OCRRegex, OCRResult, get_match_bounding_box, get_text
 from .utils import generate_keyword_processor
 
 
@@ -50,11 +50,19 @@ def find_traces(content: Union[OCRResult, str]) -> list[Prediction]:
             captured, span_info=True
         ):
             match_str = captured[span_start:span_end]
+            data = {"text": match_str, "prompt": prompt, "notify": False}
+            if (
+                bounding_box := get_match_bounding_box(
+                    content, match.start(), match.end()
+                )
+            ) is not None:
+                data["bounding_box_absolute"] = bounding_box
+
             predictions.append(
                 Prediction(
                     type=PredictionType.trace,
                     value_tag=trace_tag,
-                    data={"text": match_str, "prompt": prompt, "notify": False},
+                    data=data,
                 )
             )
 

--- a/robotoff/utils/fold_to_ascii.py
+++ b/robotoff/utils/fold_to_ascii.py
@@ -1382,6 +1382,44 @@ codepoint_to_replacement = [
 translate_table = codepoint_to_self + codepoint_to_replacement
 
 
+class TranslateTableWithoutReplacement:
+    translate_table = dict(
+        (ordinal, replacement)
+        for (ordinal, replacement) in translate_table
+        if len(replacement) == 1
+    )
+
+    def __getitem__(self, value):
+        if (replacement_value := self.translate_table.get(value)) is None:
+            return value
+        return replacement_value
+
+
+translate_table_without_replacement = TranslateTableWithoutReplacement()
+
+
+def fold_without_replacement(string: str):
+    """Replace.
+
+    Unmapped characters should be replaced with empty string by default, or other
+    replacement if provided.
+
+    All astral plane characters are always removed, even if a replacement is
+    provided.
+    """
+    if string is None:
+        return ""
+
+    try:
+        # If string contains only ASCII characters, return it.
+        string.encode("ascii")
+        return string
+    except UnicodeEncodeError:
+        pass
+
+    return string.translate(translate_table_without_replacement)
+
+
 def fold(string: str, replacement: str = "") -> str:
     """Fold string to ASCII.
 

--- a/robotoff/utils/fold_to_ascii.py
+++ b/robotoff/utils/fold_to_ascii.py
@@ -1382,23 +1382,28 @@ codepoint_to_replacement = [
 translate_table = codepoint_to_self + codepoint_to_replacement
 
 
-class TranslateTableWithoutReplacement:
-    translate_table = dict(
+class TranslateTableWithoutInsertionDeletion:
+    """Class to be used as a translate table (see `str.translate` function)
+    without any insertion or deletion: only characters with a replacement of
+    length 1 are kept from the original `translate_table` mapping."""
+
+    _translate_table = dict(
         (ordinal, replacement)
         for (ordinal, replacement) in translate_table
         if len(replacement) == 1
     )
 
     def __getitem__(self, value):
-        if (replacement_value := self.translate_table.get(value)) is None:
+        if (replacement_value := self._translate_table.get(value)) is None:
+            # Return original character if it is not in translate table
             return value
         return replacement_value
 
 
-translate_table_without_replacement = TranslateTableWithoutReplacement()
+translate_table_without_insertion_deletion = TranslateTableWithoutInsertionDeletion()
 
 
-def fold_without_replacement(string: str):
+def fold_without_insertion_deletion(string: str):
     """Replace.
 
     Unmapped characters should be replaced with empty string by default, or other
@@ -1417,7 +1422,7 @@ def fold_without_replacement(string: str):
     except UnicodeEncodeError:
         pass
 
-    return string.translate(translate_table_without_replacement)
+    return string.translate(translate_table_without_insertion_deletion)
 
 
 def fold(string: str, replacement: str = "") -> str:

--- a/robotoff/utils/text.py
+++ b/robotoff/utils/text.py
@@ -6,14 +6,14 @@ import spacy
 
 from robotoff.utils import get_logger
 
-from .fold_to_ascii import fold
+from .fold_to_ascii import fold, fold_without_replacement
 
 logger = get_logger(__name__)
 
 CONSECUTIVE_SPACES_REGEX = re.compile(r" {2,}")
 
 
-def strip_accents_ascii(s: str) -> str:
+def strip_accents_v1(s: str) -> str:
     """Transform accentuated unicode symbols into ascii or nothing
 
     Warning: this solution is only suited for languages that have a direct
@@ -33,8 +33,16 @@ def strip_accents_ascii(s: str) -> str:
     return nkfd_form.encode("ASCII", "ignore").decode("ASCII")
 
 
-def strip_accents_ascii_v2(s):
-    return fold(s)
+def strip_accents(s: str, keep_length: bool = True):
+    """Strip accents and normalize string.
+
+    :param keep_length: if True (default), no character is deleted without a
+        subtitution of length 1: the length of the string is kept unchanged.
+    """
+    if keep_length:
+        return fold_without_replacement(s)
+    else:
+        return fold(s)
 
 
 def strip_consecutive_spaces(text: str) -> str:
@@ -69,7 +77,7 @@ def get_tag(text: str) -> str:
     - replacement of punctuation by either a comma ("-") or nothing, depending
     on the punctuation
     """
-    text = strip_accents_ascii_v2(text)
+    text = strip_accents(text)
     text = (
         text.lower()
         .replace(" & ", "-")

--- a/robotoff/utils/text.py
+++ b/robotoff/utils/text.py
@@ -6,7 +6,7 @@ import spacy
 
 from robotoff.utils import get_logger
 
-from .fold_to_ascii import fold, fold_without_replacement
+from .fold_to_ascii import fold, fold_without_insertion_deletion
 
 logger = get_logger(__name__)
 
@@ -14,7 +14,7 @@ CONSECUTIVE_SPACES_REGEX = re.compile(r" {2,}")
 
 
 def strip_accents_v1(s: str) -> str:
-    """Transform accentuated unicode symbols into ascii or nothing
+    """Transform accentuated unicode symbols into ascii or nothing.
 
     Warning: this solution is only suited for languages that have a direct
     transliteration to ASCII symbols.
@@ -33,14 +33,17 @@ def strip_accents_v1(s: str) -> str:
     return nkfd_form.encode("ASCII", "ignore").decode("ASCII")
 
 
-def strip_accents(s: str, keep_length: bool = True):
+def strip_accents_v2(s: str, keep_length: bool = False) -> str:
     """Strip accents and normalize string.
 
-    :param keep_length: if True (default), no character is deleted without a
-        subtitution of length 1: the length of the string is kept unchanged.
+    :param s: the string to normalize
+    :param keep_length: if True, no character is replaced without a
+        subtitution of length 1: the length of the string is therefore kept
+        unchanged. Default to False.
+    :return: the normalized string
     """
     if keep_length:
-        return fold_without_replacement(s)
+        return fold_without_insertion_deletion(s)
     else:
         return fold(s)
 
@@ -77,7 +80,7 @@ def get_tag(text: str) -> str:
     - replacement of punctuation by either a comma ("-") or nothing, depending
     on the punctuation
     """
-    text = strip_accents(text)
+    text = strip_accents_v2(text)
     text = (
         text.lower()
         .replace(" & ", "-")

--- a/scripts/ocr/extract_ocr_text.py
+++ b/scripts/ocr/extract_ocr_text.py
@@ -351,7 +351,7 @@ class Paragraph:
 
     def get_text(self):
         """Return the text of the paragraph, by concatenating the words."""
-        return "".join(w.get_text() for w in self.words)
+        return "".join(w.text for w in self.words)
 
 
 class Word:

--- a/tests/unit/prediction/ocr/test_dataclass.py
+++ b/tests/unit/prediction/ocr/test_dataclass.py
@@ -102,3 +102,13 @@ def test_match(
 
         for match, expected_words in zip(matches, expected_matches):
             assert [word.text for word in match] == expected_words
+
+
+def test_word_offset(example_ocr_result: OCRResult):
+    assert example_ocr_result.full_text_annotation is not None
+    text = example_ocr_result.full_text_annotation.text
+    for page in example_ocr_result.full_text_annotation.pages:
+        for block in page.blocks:
+            for paragraph in block.paragraphs:
+                for word in paragraph.words:
+                    assert text[word.start_idx : word.end_idx] == word.text

--- a/tests/unit/prediction/ocr/test_dataclass.py
+++ b/tests/unit/prediction/ocr/test_dataclass.py
@@ -1,12 +1,10 @@
 import json
 import pathlib
 import re
-from typing import Callable, Optional
 
 import pytest
 
 from robotoff.prediction.ocr.dataclass import OCRParsingException, OCRResult
-from robotoff.utils.fold_to_ascii import fold
 
 data_dir = pathlib.Path(__file__).parent / "data"
 
@@ -50,58 +48,6 @@ class TestOCRResult:
             match=re.escape("Error in OCR response: [{'this is an error'}"),
         ):
             OCRResult.from_json({"responses": [{"error": [{"this is an error"}]}]})
-
-
-@pytest.mark.parametrize(
-    "pattern,expected_matches,preprocess_func",
-    [
-        (
-            "fromage de chèvre frais",
-            [
-                [
-                    "fromage ",
-                    "de ",
-                    "chèvre ",
-                    "frais ",
-                ]
-            ],
-            None,
-        ),
-        # no preprocessing, in OCR it's "Mélangez bien les pâtes" (notice the upper letter)
-        ("mélangez bien les pâtes", [], None),
-        (
-            "mélangez bien les pâtes",
-            [["Mélangez ", "bien ", "les ", "pâtes "]],
-            lambda x: x.lower(),
-        ),
-        # Fold + lowercase should return a match
-        (
-            "MELANGEZ BIEN LES PATES",
-            [["Mélangez ", "bien ", "les ", "pâtes "]],
-            lambda x: fold(x.lower()),
-        ),
-        # Test that ', ' is stripped after last word ('ciboulette, ')
-        ("brins de ciboulette", [["brins ", "de ", "ciboulette, "]], None),
-        # Test multiple matches, we expect 2 matches
-        ("rondelles", [["rondelles. "], ["rondelles "]], None),
-    ],
-)
-def test_match(
-    pattern: str,
-    expected_matches: Optional[list[list[str]]],
-    preprocess_func: Optional[Callable[[str], str]],
-    example_ocr_result: OCRResult,
-):
-    matches = example_ocr_result.match(pattern, preprocess_func)
-
-    if expected_matches is None:
-        assert matches is None
-    else:
-        assert matches is not None
-        assert len(matches) == len(expected_matches)
-
-        for match, expected_words in zip(matches, expected_matches):
-            assert [word.text for word in match] == expected_words
 
 
 def test_word_offset(example_ocr_result: OCRResult):

--- a/tests/unit/prediction/ocr/test_dataclass.py
+++ b/tests/unit/prediction/ocr/test_dataclass.py
@@ -105,6 +105,8 @@ def test_match(
 
 
 def test_word_offset(example_ocr_result: OCRResult):
+    """Check that word offsets computed by Robotoff match words in
+    'full text annotations' text."""
     assert example_ocr_result.full_text_annotation is not None
     text = example_ocr_result.full_text_annotation.text
     for page in example_ocr_result.full_text_annotation.pages:

--- a/tests/unit/prediction/ocr/test_location.py
+++ b/tests/unit/prediction/ocr/test_location.py
@@ -102,6 +102,26 @@ def test_address_extractor_init(mocker, cities):
     ]
 
 
+def test_address_extractor_get_text(mocker):
+    # OCRResult instance with a full_text_annotation
+    m_ocr_result = mocker.Mock(
+        get_full_text=mocker.Mock(return_value="full text l'île-àÉ$"),
+        text_annotations=[mocker.Mock(text="TEXT É'-č"), "yolo"],
+    )
+
+    assert AddressExtractor.get_text(m_ocr_result) == "full text l'île-àÉ$"
+    m_ocr_result.get_full_text.assert_called_once_with()
+
+    # OCRResult instance without a full_text_annotation
+    m_ocr_result = mocker.Mock(
+        get_full_text=mocker.Mock(return_value=None),
+        text_annotations=[mocker.Mock(text="TEXT É'-č"), "yolo"],
+    )
+
+    assert AddressExtractor.get_text(m_ocr_result) == "TEXT É'-č"
+    m_ocr_result.get_full_text.assert_called_once_with()
+
+
 @pytest.mark.parametrize(
     "text,output",
     [("full text l'île-àÉ$", "full text l ile ae$"), ("TEXT É'-č", "text e  c")],

--- a/tests/unit/prediction/ocr/test_location.py
+++ b/tests/unit/prediction/ocr/test_location.py
@@ -102,26 +102,6 @@ def test_address_extractor_init(mocker, cities):
     ]
 
 
-def test_address_extractor_get_text(mocker):
-    # OCRResult instance with a full_text_annotation
-    m_ocr_result = mocker.Mock(
-        get_full_text=mocker.Mock(return_value="full text l'île-àÉ$"),
-        text_annotations=[mocker.Mock(text="TEXT É'-č"), "yolo"],
-    )
-
-    assert AddressExtractor.get_text(m_ocr_result) == "full text l'île-àÉ$"
-    m_ocr_result.get_full_text.assert_called_once_with()
-
-    # OCRResult instance without a full_text_annotation
-    m_ocr_result = mocker.Mock(
-        get_full_text=mocker.Mock(return_value=None),
-        text_annotations=[mocker.Mock(text="TEXT É'-č"), "yolo"],
-    )
-
-    assert AddressExtractor.get_text(m_ocr_result) == "TEXT É'-č"
-    m_ocr_result.get_full_text.assert_called_once_with()
-
-
 @pytest.mark.parametrize(
     "text,output",
     [("full text l'île-àÉ$", "full text l ile ae$"), ("TEXT É'-č", "text e  c")],


### PR DESCRIPTION
There was quite a bit of refactoring to allow this feature, that will allow us:
- to have a bounding box of the words for every regex/flashtext detection
- to detect ingredients on photos, which is the first step to be able to compute an ingredient list photo crop automatically