### PR TITLE
feat: fix image prediction and prediction endpoints

### DIFF
--- a/doc/references/api.yml
+++ b/doc/references/api.yml
@@ -98,7 +98,6 @@ paths:
                   count:
                     type: integer
                     description: The total number of results with the provided filters
-
   /questions/random:
     get:
       tags:
@@ -137,7 +136,6 @@ paths:
                   count:
                     type: integer
                     description: The total number of results with the provided filters
-
   /questions/popular:
     get:
       tags:
@@ -215,6 +213,43 @@ paths:
                   - questions
                   - status
 
+  /predictions:
+    get:
+      tags:
+        - Predictions
+      summary: Get predictions
+      parameters:
+        - $ref: "#/components/parameters/count"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/server_type"
+        - $ref: "#/components/parameters/barcode_query_filter"
+        - name: types
+          in: query
+          description: Comma-separated list, filter by prediction types
+          schema:
+            type: string
+            example: brand,label
+      responses:
+        "200":
+          description: The queried predictions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - "no_predictions"
+                      - "found"
+                  predictions:
+                    type: array
+                    items:
+                      type: object
+                  count:
+                    type: integer
+                    description: The total number of results with the provided filters
+
   /insights/random:
     get:
       tags:
@@ -239,7 +274,6 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/InsightSearchResult"
-
   /insights/{barcode}:
     get:
       tags:
@@ -332,12 +366,7 @@ paths:
           - $ref: "#/components/parameters/server_type"
           - $ref: "#/components/parameters/value_tag"
           - $ref: "#/components/parameters/insight_types"
-          - name: barcode
-            description: Filter by product barcode
-            in: query
-            schema:
-              type: string
-              example: 0748162621021
+          - $ref: "#/components/parameters/barcode_query_filter"
           - name: annotated
             description: The annotation status of the insight.
               If not provided, both annotated and non-annotated insights are returned
@@ -478,6 +507,72 @@ paths:
                 type: object
 
 
+  /image_predictions:
+    get:
+      tags:
+        - Image Predictions
+      summary: Get image predictions
+      parameters:
+        - $ref: "#/components/parameters/count"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/server_type"
+        - $ref: "#/components/parameters/barcode_query_filter"
+        - name: with_logo
+          description: if True, only return image predictions that have associated logos (only valid for universal-logo-detector image predictions)
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: model_name
+          description: filter by name of the image predictor model
+          in: query
+          schema:
+            type: string
+            enum:
+              - universal-logo-detector
+              - nutrition-table
+              - nutriscore
+        - name: type
+          description: filter by type of the image predictor model, currently only 'object_detection'
+          in: query
+          schema:
+            type: string
+            enum:
+              - 'object_detection'
+        - name: model_version
+          description: filter by model version value
+          in: query
+          schema:
+            type: string
+        - name: min_confidence
+          description: filter by minimum confidence score value
+          in: query
+          schema:
+            type: number
+            minimum: 0.0
+            maximum: 1.0
+
+      responses:
+        "200":
+          description: The queried image predictions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - "no_image_predictions"
+                      - "found"
+                  image_predictions:
+                    type: array
+                    items:
+                      type: object
+                  count:
+                    type: integer
+                    description: The total number of results with the provided filters
+
   /images/logos:
     get:
       tags:
@@ -517,6 +612,7 @@ paths:
         meet some criteria (annotation status, annotated, type,...)
       parameters:
         - $ref: "#/components/parameters/server_type"
+        - $ref: "#/components/parameters/barcode_query_filter"
         - name: count
           description: Number of results to return
           in: query
@@ -531,11 +627,6 @@ paths:
           schema:
             type: string
           example: packager_code
-        - name: barcode
-          description: Filter by barcode
-          in: query
-          schema:
-            type: number
         - name: value
           description: Filter by annotated value
           in: query
@@ -908,11 +999,18 @@ components:
     count:
       name: count
       in: query
-      description: The number of questions to return
+      description: The number of items to return
       schema:
         type: integer
         default: 25
         minimum: 1
+    barcode_query_filter:
+      name: barcode
+      in: query
+      description: Filter by barcode value
+      schema:
+        type: string
+        example: "5410041040807"
     server_type:
       name: server_type
       in: query

--- a/robotoff/app/core.py
+++ b/robotoff/app/core.py
@@ -219,7 +219,7 @@ def get_images(
     barcode: Optional[str] = None,
     offset: Optional[int] = None,
     count: bool = False,
-    limit: Optional[int] = 25,
+    limit: Optional[int] = None,
 ) -> Iterable[ImageModel]:
     where_clauses = [ImageModel.server_type == server_type.name]
 
@@ -237,6 +237,12 @@ def get_images(
     if where_clauses:
         query = query.where(*where_clauses)
 
+    if limit is not None:
+        query = query.limit(limit)
+
+    if offset is not None:
+        query = query.offset(offset)
+
     if count:
         return query.count()
     else:
@@ -248,7 +254,7 @@ def get_predictions(
     barcode: Optional[str] = None,
     keep_types: Optional[list[str]] = None,
     value_tag: Optional[str] = None,
-    limit: Optional[int] = 25,
+    limit: Optional[int] = None,
     offset: Optional[int] = None,
     count: bool = False,
 ) -> Iterable[Prediction]:
@@ -268,7 +274,11 @@ def get_predictions(
     if where_clauses:
         query = query.where(*where_clauses)
 
-    query = query.order_by(Prediction.id.desc())
+    if limit is not None:
+        query = query.limit(limit)
+
+    if offset is not None:
+        query = query.offset(offset)
 
     if count:
         return query.count()
@@ -281,9 +291,12 @@ def get_image_predictions(
     with_logo: Optional[bool] = False,
     barcode: Optional[str] = None,
     type: Optional[str] = None,
+    model_name: Optional[str] = None,
+    model_version: Optional[str] = None,
+    min_confidence: Optional[float] = None,
     offset: Optional[int] = None,
     count: bool = False,
-    limit: Optional[int] = 25,
+    limit: Optional[int] = None,
 ) -> Iterable[ImagePrediction]:
 
     query = ImagePrediction.select()
@@ -291,11 +304,20 @@ def get_image_predictions(
     query = query.switch(ImagePrediction).join(ImageModel)
     where_clauses = [ImagePrediction.image.server_type == server_type.name]
 
-    if barcode:
+    if barcode is not None:
         where_clauses.append(ImagePrediction.image.barcode == barcode)
 
-    if type:
+    if type is not None:
         where_clauses.append(ImagePrediction.type == type)
+
+    if model_name is not None:
+        where_clauses.append(ImagePrediction.model_name == model_name)
+
+    if model_version is not None:
+        where_clauses.append(ImagePrediction.model_version == model_version)
+
+    if min_confidence is not None:
+        where_clauses.append(ImagePrediction.max_confidence >= min_confidence)
 
     if not with_logo:
         # return only images without logo
@@ -310,7 +332,11 @@ def get_image_predictions(
     if where_clauses:
         query = query.where(*where_clauses)
 
-    query = query.order_by(LogoAnnotation.image_prediction.id.desc())
+    if limit is not None:
+        query = query.limit(limit)
+
+    if offset is not None:
+        query = query.offset(offset)
 
     if count:
         return query.count()

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -847,7 +847,7 @@ def test_get_unanswered_questions_pagination(client, peewee_db):
 
 
 def test_image_prediction_collection_empty(client):
-    result = client.simulate_get("/api/v1/images/prediction/collection/")
+    result = client.simulate_get("/api/v1/image_predictions")
     assert result.status_code == 200
 
 
@@ -872,7 +872,7 @@ def test_image_prediction_collection(client, peewee_db):
 
     # test with "barcode=123" and "with_logo=True"
     result = client.simulate_get(
-        "/api/v1/images/prediction/collection",
+        "/api/v1/image_predictions",
         params={
             "barcode": "123",
             "with_logo": 1,
@@ -887,7 +887,7 @@ def test_image_prediction_collection(client, peewee_db):
 
     # test with "type=label" and "with_logo=True"
     result = client.simulate_get(
-        "/api/v1/images/prediction/collection",
+        "/api/v1/image_predictions",
         params={
             "type": "label",
             "with_logo": 1,
@@ -903,7 +903,7 @@ def test_image_prediction_collection(client, peewee_db):
 
     # test with "barcode=456" and "with_logo=True"
     result = client.simulate_get(
-        "/api/v1/images/prediction/collection",
+        "/api/v1/image_predictions",
         params={
             "barcode": "456",
             "with_logo": 1,
@@ -917,7 +917,7 @@ def test_image_prediction_collection(client, peewee_db):
 
     # test with "type=label" and "with_logo=False"
     result = client.simulate_get(
-        "/api/v1/images/prediction/collection",
+        "/api/v1/image_predictions",
         params={
             "type": "label",
         },


### PR DESCRIPTION
- limit and offset parameters were not used
- /images/predictions/collection and /images/predictions were providing the same functionality: merge them under /image_predictions route
- add these two endpoints to OpenAPI documentation
- rename `/api/v1/images/predictions/import` into `/api/v1/image_predictions/import`