### PR TITLE
fix: Fix refresh insight scheduler

### DIFF
--- a/robotoff/scheduler/__init__.py
+++ b/robotoff/scheduler/__init__.py
@@ -41,7 +41,7 @@ logger = get_logger(__name__)
 
 
 # Note: we do not use with_db, for atomicity is handled in annotator
-def process_insights():
+def process_insights() -> None:
     with db.connection_context():
         processed = 0
         insight: ProductInsight
@@ -79,7 +79,7 @@ def process_insights():
 
 
 @with_db
-def refresh_insights(with_deletion: bool = True):
+def refresh_insights(with_deletion: bool = True) -> None:
     product_store = get_min_product_store(
         ["code", "brands_tags", "countries_tags", "unique_scans_n"]
     )
@@ -234,7 +234,7 @@ def _update_data():
         logger.exception("Exception during ES indices creation", exc_info=e)
 
 
-def generate_insights():
+def generate_insights() -> None:
     """Generate and import category insights from the latest dataset dump, for
     products added at day-1."""
     logger.info("Generating new category insights")

--- a/robotoff/scheduler/__init__.py
+++ b/robotoff/scheduler/__init__.py
@@ -149,7 +149,7 @@ def refresh_insights(with_deletion: bool = True) -> None:
 def update_insight_attributes(product: Product, insight: ProductInsight) -> bool:
     updated_fields = []
     if insight.brands != product.brands_tags:
-        logger.info(
+        logger.debug(
             "Updating brand %s -> %s (%s)",
             insight.brands,
             product.brands_tags,
@@ -159,7 +159,7 @@ def update_insight_attributes(product: Product, insight: ProductInsight) -> bool
         insight.brands = product.brands_tags
 
     if insight.countries != product.countries_tags:
-        logger.info(
+        logger.debug(
             "Updating countries %s -> %s (%s)",
             insight.countries,
             product.countries_tags,
@@ -169,7 +169,7 @@ def update_insight_attributes(product: Product, insight: ProductInsight) -> bool
         insight.countries = product.countries_tags
 
     if insight.unique_scans_n != product.unique_scans_n:
-        logger.info(
+        logger.debug(
             "Updating unique scan count %s -> %s (%s)",
             insight.unique_scans_n,
             product.unique_scans_n,

--- a/robotoff/taxonomy.py
+++ b/robotoff/taxonomy.py
@@ -123,7 +123,7 @@ class TaxonomyNode:
 
 
 class Taxonomy:
-    def __init__(self):
+    def __init__(self) -> None:
         self.nodes: dict[str, TaxonomyNode] = {}
 
     def add(self, key: str, node: TaxonomyNode) -> None:

--- a/robotoff/utils/i18n.py
+++ b/robotoff/utils/i18n.py
@@ -5,7 +5,7 @@ from robotoff import settings
 
 
 class TranslationStore:
-    def __init__(self):
+    def __init__(self) -> None:
         self.translations: dict[str, gettext.NullTranslations] = {}
 
     def load(self):

--- a/scripts/clean_insights.py
+++ b/scripts/clean_insights.py
@@ -26,7 +26,7 @@ def check_field(insight: ProductInsight, field_name: str):
     return False
 
 
-def run():
+def run() -> None:
     count = 0
     errors = 0
     insight: ProductInsight

--- a/tests/unit/prediction/ocr/test_brand.py
+++ b/tests/unit/prediction/ocr/test_brand.py
@@ -9,7 +9,7 @@ from robotoff.utils import text_file_iter
 
 
 def test_check_logo_annotation_brands():
-    items: set[str] = set()
+    items = set()
 
     for item in text_file_iter(settings.OCR_LOGO_ANNOTATION_BRANDS_DATA_PATH):
         assert "||" in item

--- a/tests/unit/prediction/ocr/test_store.py
+++ b/tests/unit/prediction/ocr/test_store.py
@@ -4,7 +4,7 @@ from robotoff import settings
 from robotoff.utils import text_file_iter
 
 
-def test_check_ocr_stores():
+def test_check_ocr_stores() -> None:
     stores: set[str] = set()
     items: set[str] = set()
 


### PR DESCRIPTION
- loading min dataset in memory took +20GB of RAM, which made the
scheduler crash. By allowing a projection (selected fields) to be passed
as parameter, we reduce memory usage to ~2GB.
- Use ServerSide cursor to avoid excessive memory consumption
- Also delete predictions associated with deleted products

fixes #958
We still need to check that the image has not been deleted.