### PR TITLE
fix: always use the same queue for jobs of the same product

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,9 @@ dl-model-categorizer:
 lauch-burst-worker:
 ifdef queues
 	${DOCKER_COMPOSE} run --rm -d --no-deps worker_low python -m robotoff run-worker ${queues} --burst
+# Only launch burst worker on low priority queue if queue is not specified
 else
-	${DOCKER_COMPOSE} run --rm -d --no-deps worker_low python -m robotoff run-worker robotoff-high robotoff-low --burst
+	${DOCKER_COMPOSE} run --rm -d --no-deps worker_low python -m robotoff run-worker robotoff-low --burst
 endif
 
 #------------#
@@ -168,26 +169,26 @@ health:
 i18n-compile:
 	@echo "🥫 Compiling translations …"
 # Note it's important to have --no-deps, to avoid launching a concurrent postgres instance
-	${DOCKER_COMPOSE} run --rm --entrypoint bash --no-deps worker_high -c "cd i18n && . compile.sh"
+	${DOCKER_COMPOSE} run --rm --entrypoint bash --no-deps worker_high_1 -c "cd i18n && . compile.sh"
 
 unit-tests:
 	@echo "🥫 Running tests …"
 	# run tests in worker to have more memory
 	# also, change project name to run in isolation
-	${DOCKER_COMPOSE_TEST} run --rm worker_high poetry run pytest --cov-report xml --cov=robotoff tests/unit
+	${DOCKER_COMPOSE_TEST} run --rm worker_high_1 poetry run pytest --cov-report xml --cov=robotoff tests/unit
 
 integration-tests:
 	@echo "🥫 Running integration tests …"
 	# run tests in worker to have more memory
 	# also, change project name to run in isolation
-	${DOCKER_COMPOSE_TEST} run --rm worker_high poetry run pytest -vv --cov-report xml --cov=robotoff --cov-append tests/integration
+	${DOCKER_COMPOSE_TEST} run --rm worker_high_1 poetry run pytest -vv --cov-report xml --cov=robotoff --cov-append tests/integration
 	( ${DOCKER_COMPOSE_TEST} down -v || true )
 
 # interactive testings
 # usage: make pytest args='test/unit/my-test.py --pdb'
 pytest: guard-args
 	@echo "🥫 Running test: ${args} …"
-	${DOCKER_COMPOSE_TEST} run --rm worker_high poetry run pytest ${args}
+	${DOCKER_COMPOSE_TEST} run --rm worker_high_1 poetry run pytest ${args}
 
 #------------#
 # Production #

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ dl-model-categorizer:
 	tar -xzvf saved_model.tar.gz --strip-component=1; \
 	rm saved_model.tar.gz
 
-lauch-burst-worker:
+launch-burst-worker:
 ifdef queues
 	${DOCKER_COMPOSE} run --rm -d --no-deps worker_low python -m robotoff run-worker ${queues} --burst
 # Only launch burst worker on low priority queue if queue is not specified

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,8 +67,6 @@ services:
   worker_high_1:
     <<: *robotoff-worker
     container_name: ${COMPOSE_PROJECT_NAME:-robotoff}_worker_high_1
-    # Each worker (whether it's a high or low priority worker) listens to a
-    # single high priority queue
     command: python -m robotoff run-worker robotoff-high-1
 
   worker_high_2:
@@ -79,6 +77,8 @@ services:
   worker_low_1:
     <<: *robotoff-worker
     container_name: ${COMPOSE_PROJECT_NAME:-robotoff}_worker_low_1
+    # Each worker (whether it's a high or low priority worker) listens to a
+    # single high priority queue
     command: python -m robotoff run-worker robotoff-high-3 robotoff-low
 
   worker_low_2:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,17 @@
 version: "3.9"
 
+x-robotoff-base-volumes:
+  &robotoff-base-volumes
+  - ./data:/opt/robotoff/data
+  - ./datasets:/opt/robotoff/datasets
+  - ./tf_models:/opt/robotoff/tf_models
+  - ./models:/opt/robotoff/models
+
 x-robotoff-base:
   &robotoff-base
   restart: $RESTART_POLICY
   image: ghcr.io/openfoodfacts/robotoff:${TAG}
-  volumes:
-    - ./data:/opt/robotoff/data
-    - ./datasets:/opt/robotoff/datasets
-    - ./tf_models:/opt/robotoff/tf_models
-    - ./models:/opt/robotoff/models
+  volumes: *robotoff-base-volumes
 
 x-robotoff-base-env:
   &robotoff-base-env
@@ -40,8 +43,17 @@ x-robotoff-base-env:
   TRITON_HOST:
   ENABLE_PRODUCT_CHECK:
   IN_DOCKER_CONTAINER:
+  NUM_RQ_WORKERS: 4 # Update worker service command accordingly if you change this settings
 
-
+x-robotoff-worker-base:
+  &robotoff-worker
+  restart: $RESTART_POLICY
+  image: ghcr.io/openfoodfacts/robotoff:${TAG}
+  volumes: *robotoff-base-volumes
+  environment: *robotoff-base-env
+  depends_on:
+    - postgres
+  mem_limit: 8g
 services:
   api:
     <<: *robotoff-base
@@ -52,27 +64,27 @@ services:
     depends_on:
       - postgres
 
-  worker_high:
-    <<: *robotoff-base
-    deploy:
-      mode: replicated
-      replicas: 2
-    command: python -m robotoff run-worker robotoff-high
-    environment: *robotoff-base-env
-    depends_on:
-      - postgres
-    mem_limit: 8g
+  worker_high_1:
+    <<: *robotoff-worker
+    container_name: ${COMPOSE_PROJECT_NAME:-robotoff}_worker_high_1
+    # Each worker (whether it's a high or low priority worker) listens to a
+    # single high priority queue
+    command: python -m robotoff run-worker robotoff-high-1
 
-  worker_low:
-    <<: *robotoff-base
-    deploy:
-      mode: replicated
-      replicas: 2
-    command: python -m robotoff run-worker robotoff-high robotoff-low
-    environment: *robotoff-base-env
-    depends_on:
-      - postgres
-    mem_limit: 8g
+  worker_high_2:
+    <<: *robotoff-worker
+    container_name: ${COMPOSE_PROJECT_NAME:-robotoff}_worker_high_2
+    command: python -m robotoff run-worker robotoff-high-2
+
+  worker_low_1:
+    <<: *robotoff-worker
+    container_name: ${COMPOSE_PROJECT_NAME:-robotoff}_worker_low_1
+    command: python -m robotoff run-worker robotoff-high-3 robotoff-low
+
+  worker_low_2:
+    <<: *robotoff-worker
+    container_name: ${COMPOSE_PROJECT_NAME:-robotoff}_worker_low_2
+    command: python -m robotoff run-worker robotoff-high-4 robotoff-low
 
   scheduler:
     <<: *robotoff-base

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -33,18 +33,15 @@ x-robotoff-dev: &robotoff-dev
 services:
   api:
     <<: *robotoff-dev
-  worker_high:
+  worker_high_1:
     <<: *robotoff-dev
-    deploy:
-      mode: replicated
-      # Only 1 replica is easier to deal with for local dev
-      replicas: 0
-  worker_low:
+  worker_high_2:
     <<: *robotoff-dev
-    deploy:
-      mode: replicated
-      # Only 1 replica is easier to deal with for local dev
-      replicas: 1
+  worker_low_1:
+    <<: *robotoff-dev
+  worker_low_2:
+    <<: *robotoff-dev
+
   scheduler:
     <<: *robotoff-dev
 

--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -1054,9 +1054,7 @@ class WebhookProductResource:
         server_type = ServerType.get_from_server_domain(server_domain)
         product_id = ProductIdentifier(barcode, server_type)
 
-        # Only add the update insight job to the queue for Open Food Facts,
-        # as we don't have MongoDB connection for other projects yet
-        if action == "updated" and server_type == ServerType.off:
+        if action == "updated":
             enqueue_in_job(
                 update_insights_job,
                 get_high_queue(product_id),

--- a/robotoff/cli/main.py
+++ b/robotoff/cli/main.py
@@ -14,7 +14,6 @@ from robotoff.types import (
     PredictionType,
     ProductIdentifier,
     ServerType,
-    WorkerQueue,
 )
 
 app = typer.Typer()
@@ -33,9 +32,7 @@ def run_scheduler():
 
 @app.command()
 def run_worker(
-    queues: list[WorkerQueue] = typer.Argument(
-        ..., help="Names of the queues to listen to"
-    ),
+    queues: list[str] = typer.Argument(..., help="Names of the queues to listen to"),
     burst: bool = typer.Option(
         False, help="Run in burst mode (quit after all work is done)"
     ),
@@ -43,7 +40,7 @@ def run_worker(
     """Launch a worker."""
     from robotoff.workers.main import run
 
-    run(queues=[x.value for x in queues], burst=burst)
+    run(queues=queues, burst=burst)
 
 
 @app.command()

--- a/robotoff/settings.py
+++ b/robotoff/settings.py
@@ -333,3 +333,8 @@ INSIGHT_AUTOMATIC_PROCESSING_WAIT = int(
 # This is useful when testing locally, as we don't need the product to be in MongoDB to import
 # an image and generate insights.
 ENABLE_PRODUCT_CHECK = bool(int(os.environ.get("ENABLE_PRODUCT_CHECK", 1)))
+
+
+# Number of rq workers running, this is used to know the number of high priority queues that
+# exist
+NUM_RQ_WORKERS = int(os.environ.get("NUM_RQ_WORKERS", 4))

--- a/robotoff/types.py
+++ b/robotoff/types.py
@@ -9,11 +9,6 @@ from typing import Any, Optional
 JSONType = dict[str, Any]
 
 
-class WorkerQueue(enum.Enum):
-    robotoff_high = "robotoff-high"
-    robotoff_low = "robotoff-low"
-
-
 class ObjectDetectionModel(enum.Enum):
     nutriscore = "nutriscore"
     universal_logo_detector = "universal-logo-detector"

--- a/robotoff/workers/queues.py
+++ b/robotoff/workers/queues.py
@@ -1,3 +1,4 @@
+import random
 import threading
 import time
 from typing import Callable, Optional
@@ -5,11 +6,45 @@ from typing import Callable, Optional
 from rq import Queue
 from rq.job import Job
 
+from robotoff import settings
 from robotoff.redis import redis_conn
-from robotoff.types import WorkerQueue
+from robotoff.types import ProductIdentifier
+from robotoff.utils import get_logger
 
-high_queue = Queue(WorkerQueue.robotoff_high.value, connection=redis_conn)
-low_queue = Queue(WorkerQueue.robotoff_low.value, connection=redis_conn)
+logger = get_logger(__name__)
+high_queues = [
+    Queue(f"robotoff-high-{i+1}", connection=redis_conn)
+    for i in range(settings.NUM_RQ_WORKERS)
+]
+low_queue = Queue("robotoff-low", connection=redis_conn)
+
+
+def get_high_queue(product_id: Optional[ProductIdentifier] = None):
+    """Return the high-priority queue that is specific to a product.
+
+    There are as many high priority queues as they are workers.
+    We select one of the queues using the product barcode value.
+    This way, over all possible barcodes, all queues are returned with equal
+    probability, but we make sure we always use the same queue for a single
+    product. We greatly reduce the risk of concurrent processing, DB
+    deadlocks,...
+
+    If `product_id` is None, we return one of the high-priority queue
+    randomly.
+
+    :param product_id: the product identifier
+    :return: the selected queue
+    """
+    if product_id is None:
+        return random.choice(high_queues)
+
+    # All product barcodes should be digits, but just make sure the function still
+    # works with non-digit barcodes
+    queue_idx = (int(product_id.barcode) if product_id.barcode.isdigit() else 0) % len(
+        high_queues
+    )
+    logger.debug("Selecting queue idx %s for product %s", queue_idx, product_id)
+    return high_queues[queue_idx]
 
 
 def enqueue_in_job(
@@ -17,7 +52,7 @@ def enqueue_in_job(
     queue: Queue,
     job_delay: float,
     job_kwargs: Optional[dict] = None,
-    **kwargs
+    **kwargs,
 ):
     """Enqueue a job in `job_delay` seconds.
 

--- a/tests/unit/workers/test_queues.py
+++ b/tests/unit/workers/test_queues.py
@@ -1,0 +1,24 @@
+import pytest
+
+from robotoff.types import ProductIdentifier, ServerType
+from robotoff.workers.queues import get_high_queue
+
+
+@pytest.mark.parametrize(
+    "barcode,queue_name",
+    [
+        ("3456300016208", "robotoff-high-1"),
+        ("3456300016212", "robotoff-high-2"),
+        ("3456300016214", "robotoff-high-3"),
+        ("3456300016210", "robotoff-high-4"),
+        # check that it works too with non digit barcodes
+        ("prefix_3456300016210", "robotoff-high-3"),
+    ],
+)
+def test_get_high_queue(barcode: str, queue_name: str):
+    assert (
+        get_high_queue(
+            ProductIdentifier(barcode=barcode, server_type=ServerType.off)
+        ).name
+        == queue_name
+    )


### PR DESCRIPTION
We create as many high priority queue as they are workers, and assign each worker (whether high or low priority) to a unique queue. This way, we reduce the risk of concurrent DB write for the same product.

Also, send webhook update jobs for all projects, as we now have a MongoDB connection for all projects.