### PR TITLE
docs: incorrect link in README.md predictions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Robotoff provides an API to:
 
 Once generated, the insights can be applied automatically, or after a manual validation if necessary. A scheduler regularly marks insights for automatic annotation and sends the update to Open Food Facts.
 
-A detailed description of [how predictions and insights work is available here](https://openfoodfacts.github.io/robotoff/robotoff/explanations/predictions/).
+A detailed description of [how predictions and insights work is available here](https://openfoodfacts.github.io/robotoff/explanations/predictions/).
 
 Robotoff works together with [Product Opener](https://github.com/openfoodfacts/openfoodfacts-server), the Core server of Open Food Facts (in Perl, which can also be installed locally using Docker) and the [Open Food Facts apps](https://github.com/openfoodfacts/smooth-app) (which can work with your local instance after enabling dev mode)
 


### PR DESCRIPTION
Description:  This pull request fixes an incorrect link in the README.md file, updating it to the correct one.

Changes
 - Updated the incorrect link in the README.md file from https://openfoodfacts.github.io/robotoff/robotoff/explanations/predictions/ to https://openfoodfacts.github.io/robotoff/explanations/predictions/.

Related issue:
 - Fixes #[1096]

### What
There is an incorrect link in the README.md file. The link needs to be updated to the correct one. This issue falls under the "docs" category according to the [Commitizen Conventional Commit Types](https://github.com/commitizen/conventional-commit-types/blob/master/index.json).


### Fixes bug(s)
- ISSUE: #1096

