### PR TITLE
fix: fix error raised when releasing expired lock

### DIFF
--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -1388,7 +1388,7 @@ def import_insights_for_products(
                 try:
                     with Lock(
                         name=f"robotoff:import:{product_id.server_type.name}:{product_id.barcode}",
-                        expire=60,
+                        expire=300,
                         timeout=10,
                     ):
                         result = importer.import_insights(


### PR DESCRIPTION
See https://openfoodfacts.sentry.io/issues/4114245248/?alert_rule_id=662444&alert_timestamp=1682067470955&alert_type=email&environment=prod&project=1415205&referrer=alert_email

Job took 2 minutes, and the lock expires after 1 min. We shouldn't throw an error when trying to release a lock that expired.