### PR TITLE
chore: adding automatic backup of PostgreSQL database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,8 @@ services:
       - POSTGRES_DB
     volumes:
       - postgres-data:/var/lib/postgresql/data
+      - backup:/opt/robotoff-backups
+      - ./scripts/backup_postgres.sh:/opt/backup_postgres.sh
     command: postgres -c shared_buffers=1024MB -c work_mem=64MB
     mem_limit: 4g
     shm_size: 1g
@@ -139,6 +141,8 @@ services:
 
 volumes:
   postgres-data:
+  backup:
+    name: ${COMPOSE_PROJECT_NAME:-robotoff}_backup
   es-data:
     name: ${COMPOSE_PROJECT_NAME:-robotoff}_es-data
   redis-data:

--- a/docker/prod.yml
+++ b/docker/prod.yml
@@ -1,6 +1,10 @@
 version: "3.9"
 
 volumes:
+  backup:
+    external: true
+    name: ${COMPOSE_PROJECT_NAME:-robotoff}_backup
+
   postgres-data:
     external: true
   es-data:

--- a/scripts/backup_postgres.sh
+++ b/scripts/backup_postgres.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This script backups PostgreSQL database
+
+set -euo pipefail
+IFS=$'\n\t'
+
+echo "Performing Robotoff PostgreSQL backup"
+
+BASE_DIR=/opt/robotoff-backups/postgres
+echo "Creating $BASE_DIR if it doesn't exist"
+mkdir -p $BASE_DIR
+
+# We backup the two schemas in distinct backups, because the embedding schema is huge
+echo "Backing-up public schema..."
+# Save the backup in progress in a temporary file so that the latest dump file is always valid
+# Wait 10s max for the lock to be released (avoid concurrent dump)
+pg_dump --lock-wait-timeout=10000 --schema public -F c -U postgres postgres -f $BASE_DIR/robotoff_postgres_public.dump.tmp
+mv $BASE_DIR/robotoff_postgres_public.dump.tmp $BASE_DIR/robotoff_postgres_public.dump
+echo "public schema completed"
+
+echo "Backing-up embedding schema..."
+pg_dump --lock-wait-timeout=10000 --schema embedding -F c -U postgres postgres -f $BASE_DIR/robotoff_postgres_embedding.dump.tmp
+mv $BASE_DIR/robotoff_postgres_embedding.dump.tmp $BASE_DIR/robotoff_postgres_embedding.dump
+echo "embedding schema completed"
+
+echo "Backup completed"


### PR DESCRIPTION
Adding automatic backup of PostgreSQL database.
Backups are stored in a new ZFS dataset (`/rpool/backups/robotoff`) on OVH3.

~Backup is performed automatically every night at 0:05 using Github Actions.~

edit: the command timeout when launched through Github Action (`make backup_postgres`, but not when launched locally.
We will use either crontab or systemd timers to launche it everyday.