### PR TITLE
feat: Remove matcher predictor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ init-elasticsearch:
 	${DOCKER_COMPOSE} up -d elasticsearch 2>&1
 	@echo "Sleeping for 20s, waiting for elasticsearch to be ready..."
 	@sleep 20
-	${DOCKER_COMPOSE} run --rm --no-deps api python -m robotoff init-elasticsearch --no-load-data
+	${DOCKER_COMPOSE} run --rm --no-deps api python -m robotoff init-elasticsearch
 
 launch-burst-worker:
 ifdef queues

--- a/doc/explanations/category-prediction.md
+++ b/doc/explanations/category-prediction.md
@@ -4,24 +4,6 @@ Knowing the category of each product is critically important at Open Food Facts,
 
 In Open Food Facts, more 12,500 categories exist in the [category taxonomy](https://static.openfoodfacts.org/data/taxonomies/categories.full.json) (as of March 2023). Category prediction using product meta-data was one the first project developed as part of Robotoff in 2018.
 
-Two complementary approaches currently exist in production to predict categories: a matching-based approach and a machine learning one.
-
-## Matcher
-
-A simple "matcher" algorithm is used to predict categories from product names. This used to be done using Elasticsearch but it's directly included in Robotoff codebase [^matcher]. It currently works for the following languages: `fr`, `en`, `de`, `es`, `it`, `nl`.
-The product name and all category names in target languages are preprocessed with the following pipeline:
-
-- lowercasing
-- language-specific stop word removal
-- language-specific lookup-based lemmatization: fast and independent of part of speech for speed and simplicity
-- text normalization and accent stripping
-
-Then a category is predicted if the category name is a substring of the product name.
-
-Many false positive came from the fact some category names were also ingredients: category *fraise* matched product name *jus de fraise*. To prevent this, we only allow non-full matches (full match=the two preprocessed string are the same) to occur for an ingredient category if the match starts at the beginning of the product name. There are still false positive in English as adjectives come before nouns (ex: *strawberry juice*), so partial matching for ingredient categories is disabled for English. 
-
-## ML prediction
-
 A neural network model is used to predict categories [^neural]. Details about the model training, results and model assets are available on the [model robotoff-models release page](https://github.com/openfoodfacts/robotoff-models/releases/tag/keras-category-classifier-image-embeddings-3.0). 
 
 This model takes as inputs (all inputs are optional):
@@ -53,6 +35,6 @@ Here is a summary on the milestones in category detection:
 - 2022-10 | Remove Elasticsearch-based category predictor, switch to custom model in Robotoff codebase
 
 - 2023-03 | Deployment of the [v3 model](https://github.com/openfoodfacts/robotoff-models/releases/tag/keras-category-classifier-image-embeddings-3.0)
+- 2023-08 | Disabling of the `matcher` predictor: after an analysis through Hunger Games, most errors were due to the `matcher` predictor, and the `neural` predictor gave most of the time accurate predictions for products for which the `matcher` predictor failed.
 
-[^matcher]: see `robotoff.prediction.category.matcher`
 [^neural]: see `robotoff.prediction.category.neural`

--- a/doc/introduction/architecture.md
+++ b/doc/introduction/architecture.md
@@ -75,15 +75,9 @@ Robotoff is also notified by Product Opener every time a product is updated or d
 
 Robotoff also depends on the following services:
 
-- a single node Elasticsearch instance, used to:
-  - infer the product category from the product name, using an improved string matching algorithm. [^predict_category] (used in conjunction with ML detection)
-  - index all logos to run ANN search for automatic logo classification [^logos]
+- a single node Elasticsearch instance, used to index all logos to run ANN search for automatic logo classification [^logos]
 - a Triton instance, used to serve object detection models (nutriscore, nutrition-table, universal-logo-detector) [^robotoff_ml].
-- a Tensorflow Serving instance, used to serve the category detection model. We're going to get rid of Tensorflow Serving once a new categorizer is trained. [^robotoff_ml]
-- [robotoff-ann](https://github.com/openfoodfacts/robotoff-ann/) which uses an approximate KNN approach to predict logo label
 - MongoDB, to fetch the product latest version without querying Product Opener API.
 
-
-[^predict_category]: see `robotoff.prediction.category.matcher`
 
 [^robotoff_ml]: see `docker/ml.yml`

--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -565,7 +565,7 @@ class CategoryPredictorResource:
                 f"category predictor is only available for 'off' server type (here: '{server_type.name}')"
             )
 
-        predictors: list[str] = req.media.get("predictors") or ["neural", "matcher"]
+        predictors: list[str] = req.media.get("predictors") or ["neural"]
         neural_model_name = None
         if (neural_model_name_str := req.media.get("neural_model_name")) is not None:
             neural_model_name = NeuralCategoryClassifierModel[neural_model_name_str]

--- a/robotoff/cli/main.py
+++ b/robotoff/cli/main.py
@@ -114,21 +114,6 @@ def generate_ocr_predictions(
 
 
 @app.command()
-def predict_category(output: str) -> None:
-    """Predict categories from the product JSONL dataset stored in `datasets`
-    directory."""
-    from robotoff import settings
-    from robotoff.prediction.category.matcher import predict_from_dataset
-    from robotoff.products import ProductDataset
-    from robotoff.utils import dump_jsonl
-
-    dataset = ProductDataset(settings.JSONL_DATASET_PATH)
-    insights = predict_from_dataset(dataset)
-    dict_insights = (i.to_dict() for i in insights)
-    dump_jsonl(output, dict_insights)
-
-
-@app.command()
 def download_dataset(minify: bool = False) -> None:
     """Download Open Food Facts dataset and save it in `datasets` directory."""
     from robotoff.products import fetch_dataset, has_dataset_changed

--- a/robotoff/prediction/category/matcher.py
+++ b/robotoff/prediction/category/matcher.py
@@ -1,3 +1,10 @@
+"""Simple "matcher" algorithm is used to predict categories from product names.
+
+It's currently disabled, as categorization errors mostly come from the matcher
+predictor on Hunger Games, and as the neural categorizer almost always returns
+more accurate predictions for products for which the matcher predictor fails.
+"""
+
 import datetime
 import functools
 import itertools

--- a/robotoff/workers/main.py
+++ b/robotoff/workers/main.py
@@ -23,10 +23,8 @@ def load_resources(refresh: bool = False):
         logger.info("Loading resources in memory...")
 
     from robotoff import brands, logos, taxonomy
-    from robotoff.prediction.category import matcher
     from robotoff.prediction.object_detection import ObjectDetectionModelRegistry
 
-    matcher.load_resources()
     taxonomy.load_resources()
     logos.load_resources()
     brands.load_resources()

--- a/tests/unit/workers/tasks/test_product_updated.py
+++ b/tests/unit/workers/tasks/test_product_updated.py
@@ -17,10 +17,6 @@ DEFAULT_PRODUCT_ID = ProductIdentifier(DEFAULT_BARCODE, ServerType.off)
 
 def test_add_category_insight_no_insights(mocker):
     mocker.patch(
-        "robotoff.workers.tasks.product_updated.predict_category_matcher",
-        return_value=[],
-    )
-    mocker.patch(
         "robotoff.workers.tasks.product_updated.CategoryClassifier.predict",
         return_value=([], {}),
     )
@@ -42,10 +38,6 @@ def test_add_category_insight_with_ml_insights(mocker):
         predictor="neural",
         confidence=0.9,
         server_type=DEFAULT_PRODUCT_ID.server_type,
-    )
-    mocker.patch(
-        "robotoff.workers.tasks.product_updated.predict_category_matcher",
-        return_value=[],
     )
     mocker.patch(
         "robotoff.workers.tasks.product_updated.CategoryClassifier.predict",


### PR DESCRIPTION
Disable matcher predictor for category, as categorization errors mostly come from the matcher predictor on Hunger Games, and as the neural categorizer almost always returns more accurate predictions for products for which the matcher predictor fails.

We keep the predictor available through the API, but don't use it when products are updated.