### PR TITLE
fix: fix migration application during deployment

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -167,10 +167,9 @@ jobs:
         script_stop: false
         script: |
           cd ${{ matrix.env}}
-          # stop all containers before applying DB migrations
-          make down
-          # apply all unapplied DB migrations
+          # Apply migrations
           make migrate-db
+          # Start new version
           make up
 
     - name: Check services are up


### PR DESCRIPTION
We now apply migrations before starting the new version. Most of the time it's not an issue, and it prevents downtimes.