### PR TITLE
chore: increase SHARED_BUFFERS and WORK_MEM

### DIFF
--- a/.env
+++ b/.env
@@ -93,3 +93,10 @@ GUNICORN_PRELOAD_APP=0
 
 # The log level for the robotoff service
 LOG_LEVEL=DEBUG
+
+# PostgreSQL configuration
+
+# Use 16G in production
+ROBOTOFF_POSTGRES_SHARED_BUFFERS=1GB
+# Use 1G in production
+ROBOTOFF_POSTGRES_WORK_MEM=64MB

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -134,9 +134,13 @@ jobs:
           echo "INFLUXDB_BUCKET=off_metrics" >> .env
           echo "INFLUXDB_AUTH_TOKEN=${{ secrets.INFLUXDB_AUTH_TOKEN }}" >> .env
           echo "SLACK_TOKEN=${{ secrets.SLACK_TOKEN }}" >> .env
-          echo "GUNICORN_NUM_WORKERS=8"
+          echo "GUNICORN_NUM_WORKERS=8" >> .env
           echo "EVENTS_API_URL=https://event.openfoodfacts.${{ env.ROBOTOFF_TLD }}" >> .env
           echo "IMAGE_MODERATION_SERVICE_URL=${{ env.IMAGE_MODERATION_SERVICE_URL }}" >> .env
+
+          # PostgreSQL config
+          echo "ROBOTOFF_POSTGRES_SHARED_BUFFERS=16GB" >> .env
+          echo "ROBOTOFF_POSTGRES_WORK_MEM=1GB" >> .env
 
 
     - name: Create Docker volumes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,8 +109,8 @@ services:
       - postgres-data:/var/lib/postgresql/data
       - backup:/opt/robotoff-backups
       - ./scripts/backup_postgres.sh:/opt/backup_postgres.sh
-    command: postgres -c shared_buffers=1024MB -c work_mem=64MB
-    mem_limit: 4g
+    command: postgres -c shared_buffers=${ROBOTOFF_POSTGRES_SHARED_BUFFERS} -c work_mem=${ROBOTOFF_POSTGRES_WORK_MEM}
+    mem_limit: 20g
     shm_size: 1g
     ports:
       - "${POSTGRES_EXPOSE:-127.0.0.1:5432}:5432"


### PR DESCRIPTION
Following the suboptimal config of off-query:  https://github.com/openfoodfacts/openfoodfacts-query/issues/48

Our cache-hit for share buffers is currently 60%, while it should ideally be >90% (https://easyteam.fr/postgresql-tout-savoir-sur-le-shared_buffer/)