### PR TITLE
fix(dev_build): :zap: Add network po-default before build in make dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ goodbye:
 #-------#
 # Local #
 #-------#
-dev: hello build init-elasticsearch migrate-db up create_external_networks
+dev: hello create-po-default-network build init-elasticsearch migrate-db up create_external_networks
 	@echo "🥫 You should be able to access your local install of Robotoff at http://localhost:5500"
 
 edit_etc_hosts:
@@ -57,7 +57,6 @@ edit_etc_hosts:
 up:
 # creates a docker network and runs docker-compose
 	@echo "🥫 Building and starting containers …"
-	docker network create po_default || true  
 ifdef service
 	${DOCKER_COMPOSE} up -d ${service} 2>&1
 else
@@ -296,3 +295,7 @@ migrate-db:
 
 create-migration: guard-args
 	${DOCKER_COMPOSE} run --rm --no-deps api python -m robotoff create-migration ${args}
+
+# create network if not exists
+create-po-default-network:
+	docker network create po_default || true  


### PR DESCRIPTION
It appeared the po-default network creation comes too late in the make dev pipeline, leading to an error with init-elasticsearch. Create po-default network is added at the beginning of the pipeline instead..

### Screenshot

```bash
~/projects/openfoodfacts/robotoff main !20 ❯ make dev                                                                                                      Py base
🥫 Welcome to the Robotoff dev environment setup!
🥫 Note that the first installation might take a while to run, depending on your machine specs.
🥫 Typical installation time on 8GB RAM, 4-core CPU, and decent network bandwith is about 2 min.
🥫 Thanks for contributing to Robotoff!

docker compose --env-file=.env build api 2>&1
[+] Building 200.6s (32/32) FINISHED                                                                                                                docker:default
 => [api internal] load build definition from Dockerfile                                                                                                      0.0s
 => => transferring dockerfile: 3.12kB                                                                                                                        0.0s
 => [api internal] load metadata for docker.io/library/python:3.11-slim                                                                                       1.8s
 => [api internal] load .dockerignore                                                                                                                         0.0s
 => => transferring context: 127B                                                                                                                             0.0s
 => [api internal] load build context                                                                                                                         0.1s
 => => transferring context: 1.38MB                                                                                                                           0.1s
 => [api python-base 1/2] FROM docker.io/library/python:3.11-slim@sha256:939a263c2d00fcfb77d0fe25e7c4705282ffa4fd4d79e1b7c97266cc92430bc5                    10.0s
 => => resolve docker.io/library/python:3.11-slim@sha256:939a263c2d00fcfb77d0fe25e7c4705282ffa4fd4d79e1b7c97266cc92430bc5                                     0.0s
 => => sha256:939a263c2d00fcfb77d0fe25e7c4705282ffa4fd4d79e1b7c97266cc92430bc5 9.12kB / 9.12kB                                                                0.0s
 => => sha256:2bbbd2863f3a2cf5a60794c8cad4530d6be3c9e72f23730239146e61a345009f 1.94kB / 1.94kB                                                                0.0s
 => => sha256:13d803497f988e563809a4c2664c4b9d23883a3a7ba3fbdad6d729dcaaf43e56 6.89kB / 6.89kB                                                                0.0s
 => => sha256:efc2b5ad9eec05befa54239d53feeae3569ccbef689aa5e5dbfc25da6c4df559 29.13MB / 29.13MB                                                              7.0s
 => => sha256:60462faabbc27679d4e1a907afda153c5f2294df5f752f0e706937779faa6d22 3.51MB / 3.51MB                                                                2.0s
 => => sha256:11f0c4afa075fefa38e75f0bc033f3c60251827dfbecce64bf57bc67fc3718f0 12.87MB / 12.87MB                                                              4.9s
 => => sha256:d8393bf961f1ad054e82d4740c6557c77315c37cb25c19036e329d6194617c13 230B / 230B                                                                    2.2s
 => => sha256:e1558965ee47a72ec3c70592a93ae13e931a2d0f5719ab6c643c4a531c103236 3.21MB / 3.21MB                                                                3.4s
 => => extracting sha256:efc2b5ad9eec05befa54239d53feeae3569ccbef689aa5e5dbfc25da6c4df559                                                                     1.6s
 => => extracting sha256:60462faabbc27679d4e1a907afda153c5f2294df5f752f0e706937779faa6d22                                                                     0.2s
 => => extracting sha256:11f0c4afa075fefa38e75f0bc033f3c60251827dfbecce64bf57bc67fc3718f0                                                                     0.6s
 => => extracting sha256:d8393bf961f1ad054e82d4740c6557c77315c37cb25c19036e329d6194617c13                                                                     0.0s
 => => extracting sha256:e1558965ee47a72ec3c70592a93ae13e931a2d0f5719ab6c643c4a531c103236                                                                     0.3s
 => [api python-base 2/2] RUN apt-get update &&     apt-get install --no-install-suggests --no-install-recommends -y gettext curl build-essential &&     ap  83.2s
 => [api builder-base 1/4] RUN curl -sSL https://install.python-poetry.org | python3 -                                                                       26.1s
 => [api builder-base 2/4] WORKDIR /opt/pysetup                                                                                                               0.0s
 => [api builder-base 3/4] COPY poetry.lock  pyproject.toml poetry.toml ./                                                                                    0.1s
 => [api builder-base 4/4] RUN poetry install --without dev                                                                                                  48.1s
 => [api builder-dev 1/3] WORKDIR /opt/pysetup                                                                                                                0.0s
 => [api builder-dev 2/3] COPY poetry.lock  pyproject.toml poetry.toml ./                                                                                     0.0s
 => [api builder-dev 3/3] RUN poetry install                                                                                                                 18.3s
 => [api runtime  1/13] COPY --from=builder-base /opt/pysetup/.venv /opt/pysetup/.venv                                                                        3.6s
 => [api runtime  2/13] COPY --from=builder-base /opt/poetry /opt/poetry                                                                                      1.3s
 => [api runtime  3/13] RUN poetry config virtualenvs.create false                                                                                            1.6s
 => [api runtime  4/13] RUN groupadd -g 1000 off &&     useradd -u 1000 -g off -m off                                                                         0.5s
 => [api runtime  5/13] COPY --chown=off:off i18n /opt/robotoff/i18n                                                                                          0.2s
 => [api runtime  6/13] RUN cd /opt/robotoff/i18n &&     bash compile.sh &&     chown off:off -R /opt/robotoff/                                               1.2s
 => [api runtime  7/13] COPY --chown=off:off robotoff /opt/robotoff/robotoff/                                                                                 0.1s
 => [api runtime  8/13] COPY --chown=off:off gunicorn.py /opt/robotoff/                                                                                       0.0s
 => [api runtime  9/13] COPY --chown=off:off migrations /opt/robotoff/migrations                                                                              0.0s
 => [api runtime 10/13] COPY docker/docker-entrypoint.sh /docker-entrypoint.sh                                                                                0.0s
 => [api runtime 11/13] RUN chmod +x /docker-entrypoint.sh                                                                                                    0.5s
 => [api runtime 12/13] COPY --chown=off:off poetry.lock pyproject.toml poetry.toml /opt/robotoff/                                                            0.1s
 => [api runtime 13/13] WORKDIR /opt/robotoff                                                                                                                 0.1s
 => [api runtime-dev 1/5] COPY --from=builder-dev /opt/pysetup/.venv /opt/pysetup/.venv                                                                       3.5s
 => [api runtime-dev 2/5] COPY --from=builder-dev /opt/poetry /opt/poetry                                                                                     0.7s
 => [api runtime-dev 3/5] RUN true                                                                                                                            0.3s
 => [api runtime-dev 4/5] COPY .flake8 pyproject.toml ./                                                                                                      0.0s
 => [api runtime-dev 5/5] RUN     mkdir -p /opt/robotoff/gh_pages /opt/robotoff/doc /opt/robotoff/.cov &&     chown -R off:off /opt/robotoff/gh_pages /opt/r  0.5s
 => [api] exporting to image                                                                                                                                  4.3s
 => => exporting layers                                                                                                                                       4.3s
 => => writing image sha256:b199fc230f2591a01f68cfc4e1fdabb3b8e94d05bb2476cbffc142ec1829f46b                                                                  0.0s
 => => naming to docker.io/openfoodfacts/robotoff:dev                                                                                                         0.0s
Initializing elasticsearch indices
docker compose --env-file=.env up -d elasticsearch 2>&1
[+] Running 10/10
 ✔ elasticsearch Pulled                                                                                                                                      95.8s
   ✔ eaead16dc43b Pull complete                                                                                                                              13.1s
   ✔ a405acf5b7d4 Pull complete                                                                                                                              14.1s
   ✔ 3c517520ec4f Pull complete                                                                                                                              14.2s
   ✔ 25929c7646b5 Pull complete                                                                                                                              93.3s
   ✔ c5536f643c70 Pull complete                                                                                                                              93.4s
   ✔ 4d086f328ed5 Pull complete                                                                                                                              93.4s
   ✔ 7ba5f6dc1b84 Pull complete                                                                                                                              93.4s
   ✔ f61b0936755b Pull complete                                                                                                                              93.5s
   ✔ dbdbfbe00efb Pull complete                                                                                                                              93.5s
Error response from daemon: network po_default not found
make: *** [Makefile:153: init-elasticsearch] Error 1
```