### PR TITLE
fix: Improve perf random logo search

### DIFF
--- a/migrations/007_add_logo_annotation_server_type_index.py
+++ b/migrations/007_add_logo_annotation_server_type_index.py
@@ -1,0 +1,12 @@
+import peewee as pw
+from peewee_migrate import Migrator
+
+
+def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
+    migrator.sql(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS logo_annotation_server_type ON logo_annotation (server_type)"
+    )
+
+
+def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
+    migrator.sql("DROP INDEX IF EXISTS logo_annotation_server_type")

--- a/robotoff/cli/main.py
+++ b/robotoff/cli/main.py
@@ -654,6 +654,7 @@ def add_logo_to_ann(
         seen = set(int(x) for x in text_file_iter(existing_ids_path))
     else:
         seen = get_stored_logo_ids(es_client)
+    logger.info("Number of existing logos: %d", len(seen))
 
     added = 0
 


### PR DESCRIPTION
Fixes #1386.

We use the newly indexed column `logo_annotation.server_type` to filter logos of a specific `server_type`.
Note that the sampling fraction we've chosen (20%) may not be adapted depending on how infrequent a certain `server_type` is. Currently, we only have logos with `server_type=off`, so we can keep it this way.