### PR TITLE
fix: fix entity aggregation bug for NER detection

### DIFF
--- a/robotoff/prediction/ingredient_list/__init__.py
+++ b/robotoff/prediction/ingredient_list/__init__.py
@@ -182,6 +182,7 @@ def predict_batch(
             "input_ids": batch_encoding.input_ids[idx],
             "offset_mapping": batch_encoding.offset_mapping[idx],
             "special_tokens_mask": batch_encoding.special_tokens_mask[idx],
+            "word_ids": batch_encoding.word_ids(idx),
         }
         pipeline_output = pipeline.postprocess(model_outputs, aggregation_strategy)
 


### PR DESCRIPTION
It looks like it’s because we’re using the “FIRST” aggregation strategy, with a tokenizer that is not word-aware: we’re falling back to some heuristics (the presence of spaces before/after the word), that somehow fails here.
Indeed, XLM-RoBERTa model does not use the same tokenizer as RoBERTa, and uses an Unigram model (instead of BPE), which is not word-aware.
Another issue of the “FIRST” aggregation strategy is that the ending dot after the ingredient list is predicted as part of the ingredient list, even though it’s not in the non-aggregated prediction. By switching to “SIMPLE” strategy (a strategy without an error correction mechanism), we don’t have this issue anymore, but two subwords belonging to the same word are sometimes predicted as belonging to two entities.
A more in-depth analysis of the TokenClassificationPipeline reveals that the issue comes from the Punctuation() pre-tokenizer we added: it was not included in the original tokenizer, and the heuristic doesn’t take it into account, leading to an incorrect detection. I updated the heuristic to use the `word_ids` provided by the tokenizer to know whether the token is a subword or not (with respect to the pre-tokenization output).
By updating the way entities are aggregated, we don't have an issue anymore with the first aggregation strategy: we keep it as it.