### PR TITLE
feat: Spellcheck annotate

### DIFF
--- a/doc/references/api.yml
+++ b/doc/references/api.yml
@@ -344,11 +344,12 @@ paths:
                   description: ID of the insight
                 annotation:
                   type: integer
-                  description: "Annotation of the prediction: 1 to accept the prediction, 0 to refuse it, and -1 for _skip_"
+                  description: "Annotation of the prediction: 1 to accept the prediction, 0 to refuse it, and -1 for _skip_, 2 to accept and add data"
                   enum:
                     - 0
                     - 1
                     - -1
+                    - 2
                 update:
                   type: integer
                   description: "Send the update to Openfoodfacts if `update=1`, don't send the update otherwise. This parameter is useful if the update is performed client-side"
@@ -356,6 +357,10 @@ paths:
                   enum:
                     - 0
                     - 1
+                data:
+                  type: object
+                  description: "Additional data provided by the user as key-value pairs"
+
               required:
                 - "insight_id"
                 - "annotation"

--- a/doc/references/api.yml
+++ b/doc/references/api.yml
@@ -329,7 +329,7 @@ paths:
         The annotation is an integer that can take 4 values: `0`, `1`, `2`, `-1`. `0` means the insight is incorrect
         (so it won't be applied), `1` means it is correct (so it will be applied) and `-1` means the insight
         won't be returned to the user (_skip_). `2` is used when user submit some data to the annotate endpoint 
-        (for example in some cases of category annotation).
+        (for example in some cases of category annotation or ingredients spellcheck).
         
         We use the voting mecanism system to remember which insight to skip for a user (authenticated or not).
       requestBody:

--- a/robotoff/insights/annotate.py
+++ b/robotoff/insights/annotate.py
@@ -688,9 +688,9 @@ class IngredientSpellcheckAnnotator(InsightAnnotator):
         is_vote: bool = False,
     ) -> AnnotationResult:
         # Possibility for the annotator to change the spellcheck correction if data is provided
-        if data:
+        if data is not None:
             annotation = data.get("annotation")
-            if not annotation and len(data) > 1:
+            if not annotation or len(data) > 1:
                 return INVALID_DATA
             # We add the new annotation to the Insight.
             json_data = insight.data

--- a/robotoff/insights/annotate.py
+++ b/robotoff/insights/annotate.py
@@ -24,6 +24,7 @@ from robotoff.off import (
     update_emb_codes,
     update_expiration_date,
     update_quantity,
+    save_ingredients,
 )
 from robotoff.products import get_image_id, get_product
 from robotoff.types import InsightAnnotation, InsightType, JSONType
@@ -98,6 +99,12 @@ FAILED_UPDATE_RESULT = AnnotationResult(
     status_code=AnnotationStatus.error_failed_update.value,
     status=AnnotationStatus.error_failed_update.name,
     description="Open Food Facts update failed",
+)
+
+INVALID_DATA = AnnotationResult(
+    status_code=AnnotationStatus.error_invalid_data.value,
+    status=AnnotationStatus.error_invalid_data.name,
+    description="The data schema is invalid."
 )
 
 
@@ -669,7 +676,39 @@ class NutritionTableStructureAnnotator(InsightAnnotator):
     @classmethod
     def is_data_required(cls) -> bool:
         return True
+    
 
+class IngredientSpellcheckAnnotator(InsightAnnotator):
+    @classmethod
+    def process_annotation(
+        cls,
+        insight: ProductInsight,
+        data: Optional[dict] = None,
+        auth: Optional[OFFAuthentication] = None,
+        is_vote: bool = False,
+    ) -> AnnotationResult:
+        # Possibility for the annotator to change the spellcheck correction if data is provided
+        if data:
+            annotation = data.get("annotation")
+            if not annotation and len(data) > 1:
+                return INVALID_DATA
+            # We add the new annotation to the Insight.
+            json_data = insight.data
+            json_data["annotation"] = annotation
+            insight.data = json_data
+            insight.save()
+        
+        ingredient_text = data.get("annotation") if data else insight.data["correction"]
+        save_ingredients(
+            product_id=insight.get_product_id(),
+            ingredient_text=ingredient_text,
+            lang=insight.value_tag,
+            insight_id=insight.id,
+            auth=auth,
+            is_vote=is_vote
+        )
+        return UPDATED_ANNOTATION_RESULT
+    
 
 ANNOTATOR_MAPPING: dict[str, Type] = {
     InsightType.packager_code.name: PackagerCodeAnnotator,
@@ -683,6 +722,7 @@ ANNOTATOR_MAPPING: dict[str, Type] = {
     InsightType.nutrition_image.name: NutritionImageAnnotator,
     InsightType.nutrition_table_structure.name: NutritionTableStructureAnnotator,
     InsightType.is_upc_image.name: UPCImageAnnotator,
+    InsightType.ingredient_spellcheck.name: IngredientSpellcheckAnnotator,
 }
 
 

--- a/robotoff/insights/annotate.py
+++ b/robotoff/insights/annotate.py
@@ -19,12 +19,12 @@ from robotoff.off import (
     add_label_tag,
     add_packaging,
     add_store,
+    save_ingredients,
     select_rotate_image,
     unselect_image,
     update_emb_codes,
     update_expiration_date,
     update_quantity,
-    save_ingredients,
 )
 from robotoff.products import get_image_id, get_product
 from robotoff.types import InsightAnnotation, InsightType, JSONType
@@ -104,7 +104,7 @@ FAILED_UPDATE_RESULT = AnnotationResult(
 INVALID_DATA = AnnotationResult(
     status_code=AnnotationStatus.error_invalid_data.value,
     status=AnnotationStatus.error_invalid_data.name,
-    description="The data schema is invalid."
+    description="The data schema is invalid.",
 )
 
 
@@ -676,7 +676,7 @@ class NutritionTableStructureAnnotator(InsightAnnotator):
     @classmethod
     def is_data_required(cls) -> bool:
         return True
-    
+
 
 class IngredientSpellcheckAnnotator(InsightAnnotator):
     @classmethod
@@ -697,7 +697,7 @@ class IngredientSpellcheckAnnotator(InsightAnnotator):
             json_data["annotation"] = annotation
             insight.data = json_data
             insight.save()
-        
+
         ingredient_text = data.get("annotation") if data else insight.data["correction"]
         save_ingredients(
             product_id=insight.get_product_id(),
@@ -705,10 +705,10 @@ class IngredientSpellcheckAnnotator(InsightAnnotator):
             lang=insight.value_tag,
             insight_id=insight.id,
             auth=auth,
-            is_vote=is_vote
+            is_vote=is_vote,
         )
         return UPDATED_ANNOTATION_RESULT
-    
+
 
 ANNOTATOR_MAPPING: dict[str, Type] = {
     InsightType.packager_code.name: PackagerCodeAnnotator,


### PR DESCRIPTION
### What
Add Ingredients Spellcheck contributor annotation to `insight/annotate` route.

Now, the contributor can either validate or modify the model correction .
This modification is later added to `insights.data` in addition to be updated in the database.

### Part of 
- Spellcheck