### PR TITLE
fix: fix nutrition extraction insight generation

### DIFF
--- a/robotoff/prediction/nutrition_extraction.py
+++ b/robotoff/prediction/nutrition_extraction.py
@@ -439,12 +439,15 @@ def postprocess_aggregated_entities(
                 logger.warning("Could not extract nutrient value from %s", words_str)
                 is_valid = False
 
-        # Reformat the nutrient name so that it matches Open Food Facts format
-        # Ex: "ENERGY_KCAL_100G" -> "energy-kcal_100g"
-        entity_label = entity["entity"].lower()
-        entity_base, entity_per = entity_label.rsplit("_", 1)
-        entity_base = entity_base.replace("_", "-")
-        entity_label = f"{entity_base}_{entity_per}"
+        if entity["entity"] == "SERVING_SIZE":
+            entity_label = "serving_size"
+        else:
+            # Reformat the nutrient name so that it matches Open Food Facts format
+            # Ex: "ENERGY_KCAL_100G" -> "energy-kcal_100g"
+            entity_label = entity["entity"].lower()
+            entity_base, entity_per = entity_label.rsplit("_", 1)
+            entity_base = entity_base.replace("_", "-")
+            entity_label = f"{entity_base}_{entity_per}"
         postprocessed_entity = {
             "entity": entity_label,
             "text": words_str,

--- a/robotoff/prediction/nutrition_extraction.py
+++ b/robotoff/prediction/nutrition_extraction.py
@@ -439,8 +439,14 @@ def postprocess_aggregated_entities(
                 logger.warning("Could not extract nutrient value from %s", words_str)
                 is_valid = False
 
+        # Reformat the nutrient name so that it matches Open Food Facts format
+        # Ex: "ENERGY_KCAL_100G" -> "energy-kcal_100g"
+        entity_label = entity["entity"].lower()
+        entity_base, entity_per = entity_label.rsplit("_", 1)
+        entity_base = entity_base.replace("_", "-")
+        entity_label = f"{entity_base}_{entity_per}"
         postprocessed_entity = {
-            "entity": entity["entity"].lower(),
+            "entity": entity_label,
             "text": words_str,
             "value": value,
             "unit": unit,

--- a/tests/ml/test_nutrition_extraction.py
+++ b/tests/ml/test_nutrition_extraction.py
@@ -91,7 +91,7 @@ def test_predict(
         output_filename = output_url.split("/")[-1]
 
         with (output_dir / output_filename).open("wt") as f:
-            json.dump(dataclasses.asdict(result), f)
+            json.dump(dataclasses.asdict(result), f, indent=4)
     elif is_output_available:
         r = get_asset_from_url(output_url)
         assert r is not None

--- a/tests/unit/prediction/test_nutrition_extraction.py
+++ b/tests/unit/prediction/test_nutrition_extraction.py
@@ -19,7 +19,7 @@ class TestProcessAggregatedEntities:
         ]
         expected_output = [
             {
-                "entity": "energy_kcal_100g",
+                "entity": "energy-kcal_100g",
                 "text": "525 kcal",
                 "value": "525",
                 "unit": "kcal",
@@ -56,7 +56,7 @@ class TestProcessAggregatedEntities:
         ]
         expected_output = [
             {
-                "entity": "energy_kcal_100g",
+                "entity": "energy-kcal_100g",
                 "text": "525 kcal",
                 "value": "525",
                 "unit": "kcal",
@@ -69,7 +69,7 @@ class TestProcessAggregatedEntities:
                 "invalid_reason": "multiple_entities",
             },
             {
-                "entity": "energy_kcal_100g",
+                "entity": "energy-kcal_100g",
                 "text": "126 kcal",
                 "value": "126",
                 "unit": "kcal",
@@ -87,7 +87,7 @@ class TestProcessAggregatedEntities:
     def test_postprocess_aggregated_entities_no_value(self):
         aggregated_entities = [
             {
-                "entity": "FAT_SERVING",
+                "entity": "SATURATED_FAT_SERVING",
                 "words": ["fat"],
                 "score": 0.85,
                 "start": 0,
@@ -98,7 +98,7 @@ class TestProcessAggregatedEntities:
         ]
         expected_output = [
             {
-                "entity": "fat_serving",
+                "entity": "saturated-fat_serving",
                 "text": "fat",
                 "value": None,
                 "unit": None,
@@ -219,7 +219,7 @@ class TestProcessAggregatedEntities:
         ]
         expected_output = [
             {
-                "entity": "energy_kj_100g",
+                "entity": "energy-kj_100g",
                 "text": "525",
                 "value": "525",
                 "unit": "kj",
@@ -231,7 +231,7 @@ class TestProcessAggregatedEntities:
                 "valid": True,
             },
             {
-                "entity": "energy_kcal_100g",
+                "entity": "energy-kcal_100g",
                 "text": "126 kcal",
                 "value": "126",
                 "unit": "kcal",


### PR DESCRIPTION
- use exaclly the same nutrient name format as in Open Food Facts
- import `nutrition_extraction` insight if it brings at least one nutrient that was not in the product current nutrients.
- add unit tests for the import mechanism