### PR TITLE
fix: fix KeyError exception in UPCImageImporter

### DIFF
--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -1129,7 +1129,7 @@ class UPCImageImporter(InsightImporter):
                     image_data["imgid"]
                     for key, image_data in product.images.items()
                     # only look for non-raw images here (=selected images)
-                    if not key.isdigit()
+                    if not key.isdigit() and "imgid" in image_data
                 ):
                     # We check that at least one selected image has the image
                     # ID as reference before creating the insight


### PR DESCRIPTION
some products have an empty "images.nutrition" dict we check here that imgid key exists in the image data

fixes #1442