### PR TITLE
fix: restart gunicorn workers every 50 requests

### DIFF
--- a/gunicorn.py
+++ b/gunicorn.py
@@ -9,3 +9,7 @@ worker_connections = 1000
 # Default to True (production) if not specified
 preload_app = bool(os.environ.get("GUNICORN_PRELOAD_APP", True))
 timeout = 60
+# Limit the impact of caching on RAM use by restarting workers
+# every 50 requests
+max_requests = 50
+max_requests_jitter = 5


### PR DESCRIPTION
This is done to limit the effect of asset caching or of possible memory leaks on the RAM consumption on gunicorn workers.