### PR TITLE
fix: allow to filter insights by campaign

### DIFF
--- a/doc/references/api.yml
+++ b/doc/references/api.yml
@@ -313,6 +313,7 @@ paths:
         - $ref: "#/components/parameters/insight_order_by"
         - $ref: "#/components/parameters/count"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/campaigns"
       responses:
         "200":
           description: ""
@@ -1424,7 +1425,8 @@ components:
       name: campaigns
       in: query
       description: Filter by annotation campaigns (the insight must have all the campaigns)
-        An annotation campaigns allows to only retrieve questions about selected products, based on arbitrary criteria
+        An annotation campaign allows to only retrieve questions or insights based on arbitrary criteria
+        defined during insight import.
       schema:
         type: string
         example: agribalyse-category

--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -208,8 +208,9 @@ class InsightCollection:
         brands = req.get_param_as_list("brands") or None
         predictor = req.get_param("predictor")
         server_type = get_server_type_from_req(req)
-        countries: Optional[list[Country]] = get_countries_from_req(req)
-        order_by: Optional[str] = req.get_param("order_by")
+        countries: list[Country] | None = get_countries_from_req(req)
+        order_by: str | None = req.get_param("order_by")
+        campaigns: list[str] | None = req.get_param_as_list("campaigns") or None
 
         if order_by not in ("random", "popularity", None):
             raise falcon.HTTPBadRequest(
@@ -236,6 +237,7 @@ class InsightCollection:
             barcode=barcode,
             predictor=predictor,
             order_by=order_by,
+            campaigns=campaigns,
         )
 
         offset: int = (page - 1) * count


### PR DESCRIPTION
Add a new `campaigns` filter to /api/v1/insights route.