### PR TITLE
feat: improve /image_predictions route

### DIFF
--- a/doc/references/api.yml
+++ b/doc/references/api.yml
@@ -530,6 +530,12 @@ paths:
           schema:
             type: string
             example: universal-logo-detector
+        - name: image_id
+          description: filter by image ID. It should be a digit (raw images only), otherwise no result will be returned.
+          in: query
+          schema:
+            type: string
+            example: 1
         - name: type
           description: filter by type of the image predictor model
           in: query

--- a/doc/references/api.yml
+++ b/doc/references/api.yml
@@ -516,27 +516,26 @@ paths:
         - $ref: "#/components/parameters/server_type"
         - $ref: "#/components/parameters/barcode_query_filter"
         - name: with_logo
-          description: if True, only return image predictions that have associated logos (only valid for universal-logo-detector image predictions)
+          description: if True, only return image predictions that have associated logos
+            (only valid for universal-logo-detector image predictions). If false, only return image predictions that have no associated logos.
+            Otherwise, return all image predictions.
           in: query
           schema:
             type: boolean
-            default: false
+            default: null
+            nullable: true
         - name: model_name
           description: filter by name of the image predictor model
           in: query
           schema:
             type: string
-            enum:
-              - universal-logo-detector
-              - nutrition-table
-              - nutriscore
+            example: universal-logo-detector
         - name: type
-          description: filter by type of the image predictor model, currently only 'object_detection'
+          description: filter by type of the image predictor model
           in: query
           schema:
             type: string
-            enum:
-              - 'object_detection'
+            example: object_detection
         - name: model_version
           description: filter by model version value
           in: query

--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -834,7 +834,7 @@ class ImagePredictionResource:
     def on_get(self, req: falcon.Request, resp: falcon.Response):
         count: int = req.get_param_as_int("count", min_value=1, default=25)
         page: int = req.get_param_as_int("page", min_value=1, default=1)
-        with_logo: Optional[bool] = req.get_param_as_bool("with_logo", default=False)
+        with_logo: bool | None = req.get_param_as_bool("with_logo", default=None)
         model_name: Optional[str] = req.get_param("model_name")
         type_: Optional[str] = req.get_param("type")
         model_version: Optional[str] = req.get_param("model_version")

--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -835,17 +835,19 @@ class ImagePredictionResource:
         count: int = req.get_param_as_int("count", min_value=1, default=25)
         page: int = req.get_param_as_int("page", min_value=1, default=1)
         with_logo: bool | None = req.get_param_as_bool("with_logo", default=None)
-        model_name: Optional[str] = req.get_param("model_name")
-        type_: Optional[str] = req.get_param("type")
-        model_version: Optional[str] = req.get_param("model_version")
-        barcode: Optional[str] = normalize_req_barcode(req.get_param("barcode"))
-        min_confidence: Optional[float] = req.get_param_as_float("min_confidence")
+        model_name: str | None = req.get_param("model_name")
+        type_: str | None = req.get_param("type")
+        model_version: str | None = req.get_param("model_version")
+        barcode: str | None = normalize_req_barcode(req.get_param("barcode"))
+        image_id: str | None = req.get_param("image_id")
+        min_confidence: float | None = req.get_param_as_float("min_confidence")
         server_type = get_server_type_from_req(req)
 
         get_image_predictions_ = functools.partial(
             get_image_predictions,
             with_logo=with_logo,
             barcode=barcode,
+            image_id=image_id,
             type=type_,
             server_type=server_type,
             model_name=model_name,

--- a/robotoff/app/core.py
+++ b/robotoff/app/core.py
@@ -303,20 +303,24 @@ def get_predictions(
 
 def get_image_predictions(
     server_type: ServerType,
-    with_logo: Optional[bool] = False,
-    barcode: Optional[str] = None,
-    type: Optional[str] = None,
-    model_name: Optional[str] = None,
-    model_version: Optional[str] = None,
-    min_confidence: Optional[float] = None,
-    offset: Optional[int] = None,
+    with_logo: bool | None = False,
+    barcode: str | None = None,
+    type: str | None = None,
+    model_name: str | None = None,
+    model_version: str | None = None,
+    min_confidence: float | None = None,
+    image_id: str | None = None,
+    offset: int | None = None,
     count: bool = False,
-    limit: Optional[int] = None,
+    limit: int | None = None,
 ) -> Iterable[ImagePrediction]:
     query = ImagePrediction.select()
 
     query = query.switch(ImagePrediction).join(ImageModel)
     where_clauses = [ImagePrediction.image.server_type == server_type.name]
+
+    if image_id is not None:
+        where_clauses.append(ImagePrediction.image.image_id == image_id)
 
     if barcode is not None:
         where_clauses.append(ImagePrediction.image.barcode == barcode)


### PR DESCRIPTION
- don't perform a join by default with logo_annotation table when calling the endpoint.
- allow to filter by image_id in /api/v1/image_predictions