### PR TITLE
feat: low queue for mass updates

### DIFF
--- a/robotoff/workers/queues.py
+++ b/robotoff/workers/queues.py
@@ -56,6 +56,12 @@ def get_high_queue(product_id: Optional[ProductIdentifier] = None) -> Queue:
     return high_queues[queue_idx]
 
 
+
+def get_low_queue() -> Queue:
+    """Return the low-priority queue."""
+    return low_queue
+
+
 def enqueue_in_job(
     func: Callable,
     queue: Queue,

--- a/robotoff/workers/queues.py
+++ b/robotoff/workers/queues.py
@@ -56,7 +56,6 @@ def get_high_queue(product_id: Optional[ProductIdentifier] = None) -> Queue:
     return high_queues[queue_idx]
 
 
-
 def get_low_queue() -> Queue:
     """Return the low-priority queue."""
     return low_queue

--- a/robotoff/workers/update_listener.py
+++ b/robotoff/workers/update_listener.py
@@ -37,8 +37,7 @@ class UpdateListener(BaseUpdateListener):
         product_id = ProductIdentifier(redis_update.code, server_type)
 
         # Check if the update was triggered by scanbot or specific mass update accounts
-        is_scanbot_or_mass_update = redis_update.triggered_by in ["scanbot", "mass_update_account_1", "mass_update_account_2"]
-
+        is_scanbot_or_mass_update = redis_update.user_id in ["scanbot", "update_all_products"]
         # Select queue based on triggering actor
         selected_queue = get_low_queue(product_id) if is_scanbot_or_mass_update else get_high_queue(product_id)
 

--- a/robotoff/workers/update_listener.py
+++ b/robotoff/workers/update_listener.py
@@ -7,7 +7,12 @@ from redis import Redis
 from robotoff import settings
 from robotoff.types import ProductIdentifier, ServerType
 from robotoff.utils.logger import get_logger
-from robotoff.workers.queues import enqueue_in_job, enqueue_job, get_high_queue, get_low_queue
+from robotoff.workers.queues import (
+    enqueue_in_job,
+    enqueue_job,
+    get_high_queue,
+    get_low_queue,
+)
 from robotoff.workers.tasks import delete_product_insights_job
 from robotoff.workers.tasks.import_image import run_import_image_job
 from robotoff.workers.tasks.product_updated import update_insights_job
@@ -37,9 +42,14 @@ class UpdateListener(BaseUpdateListener):
         product_id = ProductIdentifier(redis_update.code, server_type)
 
         # Check if the update was triggered by scanbot or specific mass update accounts
-        is_scanbot_or_mass_update = redis_update.user_id in ["scanbot", "update_all_products"]
+        is_scanbot_or_mass_update = redis_update.user_id in [
+            "scanbot",
+            "update_all_products",
+        ]
         # Select queue based on triggering actor
-        selected_queue = get_low_queue(product_id) if is_scanbot_or_mass_update else get_high_queue(product_id)
+        selected_queue = (
+            get_low_queue() if is_scanbot_or_mass_update else get_high_queue(product_id)
+        )
 
         if action == "deleted":
             logger.info("Product %s has been deleted", redis_update.code)

--- a/robotoff/workers/update_listener.py
+++ b/robotoff/workers/update_listener.py
@@ -7,7 +7,7 @@ from redis import Redis
 from robotoff import settings
 from robotoff.types import ProductIdentifier, ServerType
 from robotoff.utils.logger import get_logger
-from robotoff.workers.queues import enqueue_in_job, enqueue_job, get_high_queue
+from robotoff.workers.queues import enqueue_in_job, enqueue_job, get_high_queue, get_low_queue
 from robotoff.workers.tasks import delete_product_insights_job
 from robotoff.workers.tasks.import_image import run_import_image_job
 from robotoff.workers.tasks.product_updated import update_insights_job
@@ -16,8 +16,7 @@ logger = get_logger(__name__)
 
 
 def get_redis_client():
-    """Get the Redis client where Product Opener publishes it's product
-    update."""
+    """Get the Redis client where Product Opener publishes its product updates."""
     return Redis(
         host=settings.REDIS_UPDATE_HOST,
         port=settings.REDIS_UPDATE_PORT,
@@ -36,11 +35,18 @@ class UpdateListener(BaseUpdateListener):
         action = redis_update.action
         server_type = ServerType.from_product_type(redis_update.product_type)
         product_id = ProductIdentifier(redis_update.code, server_type)
+
+        # Check if the update was triggered by scanbot or specific mass update accounts
+        is_scanbot_or_mass_update = redis_update.triggered_by in ["scanbot", "mass_update_account_1", "mass_update_account_2"]
+
+        # Select queue based on triggering actor
+        selected_queue = get_low_queue(product_id) if is_scanbot_or_mass_update else get_high_queue(product_id)
+
         if action == "deleted":
             logger.info("Product %s has been deleted", redis_update.code)
             enqueue_job(
                 delete_product_insights_job,
-                get_high_queue(product_id),
+                selected_queue,
                 job_kwargs={"result_ttl": 0},
                 product_id=product_id,
             )
@@ -69,7 +75,7 @@ class UpdateListener(BaseUpdateListener):
                 )
                 enqueue_job(
                     run_import_image_job,
-                    get_high_queue(product_id),
+                    selected_queue,
                     job_kwargs={"result_ttl": 0},
                     product_id=product_id,
                     image_url=image_url,
@@ -79,7 +85,7 @@ class UpdateListener(BaseUpdateListener):
                 logger.info("Product %s has been updated", redis_update.code)
                 enqueue_in_job(
                     update_insights_job,
-                    get_high_queue(product_id),
+                    selected_queue,
                     settings.UPDATED_PRODUCT_WAIT,
                     job_kwargs={"result_ttl": 0},
                     product_id=product_id,
@@ -91,7 +97,7 @@ def run_update_listener():
     """Run the update import daemon.
 
     This daemon listens to the Redis stream containing information about
-    product updates, and triggers
+    product updates and triggers appropriate actions.
     """
     redis_client = get_redis_client()
     update_listener = UpdateListener(


### PR DESCRIPTION
When there is a massive update on the Open Food Facts server, put them in lower priority queues, to keep user submissions in high priorities, and be able to ask them question quickly.

fixes: #1519
