### PR TITLE
docs: clarify Robotoff intro paragraph in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@
   <img height="48" src="https://static.openfoodfacts.org/images/logos/off-logo-horizontal-light.svg">
 </picture>
 
-**Robotoff** is a service managing potential Open Food Facts updates (also known as _insights_) and predictions (which can then be combined to generate an insight).
-These insights include a growing set of facts, including:
+**Robotoff** is a service that generates predictions from product data such as images, text, and metadata. These predictions can individually or collectively be refined into actionable suggestions known as insights. Insights serve as potential updates to the Open Food Facts database, either automatically applied when highly confident or validated manually by human annotators. These insights cover a growing set of product facts, including:	
 
 - the product category, weight, brand, packager codes and expiration date
 - some of its labels


### PR DESCRIPTION
Reason for change:
The original sentence was somewhat unclear and internally inconsistent — it treated "updates," "insights," and "predictions" as if they were all on the same level, but later implied that predictions are combined to form insights. After reviewing the flow of how Robotoff works, I reworded the description to better reflect its role in managing the full process from predictions to user-reviewed updates. Explanation based on the Predictions and Insights docs (https://openfoodfacts.github.io/robotoff/explanations/predictions/)

### What
- Updated the first paragraph of the README.md file
- Clarified the relationships between predictions, insights, and updates

### Screenshot
Not applicable — documentation only (Markdown text edit)

### Fixes bug(s)
None

### Part of 
Minor documentation improvements (no issue filed yet)

