### PR TITLE
Add bounding box to nutrition extraction

### DIFF
--- a/doc/references/predictions/nutrient-extraction.md
+++ b/doc/references/predictions/nutrient-extraction.md
@@ -125,6 +125,9 @@ Postprocessed entities contain the following fields:
 - `char_start`: the character start index of the entity, with respect to the original OCR JSON
 - `char_end` : the character end index of the entity, with respect to the original OCR JSON
 - `valid`: whether the extracted entity is valid. We consider an entity invalid if we couldn't extract nutrient value from the `text` field, or if there are more than one entity for a single nutrient. For example, two `proteins_100g` entities are both considered invalid, but one `proteins_100g` and one `proteins_serving` are considered valid.
+- `bounding_box_absolute`: the bounding box coordinates of the entity in absolute pixel values (y_min, x_min, y_max, x_max).
+
+In addition to these entity fields, the prediction also includes a `bounding_box` field, which represents the bounding box coordinates for the whole nutrition area calculated from all the entities.
 
 ### Integration
 
@@ -132,6 +135,16 @@ For every new uploaded image, the model is run on this image [^extract_nutrition
 If some entities were detected, we create a `Prediction` in DB using the usual import mechanism [^import_mechanism], under the type `nutrient_extraction`.
 
 We only create an insight if we detected at least one nutrient value that is not in the product nutrients [^nutrient_extraction_import].
+
+### Validation
+
+When validating nutrition extraction insights, users can:
+
+1. Accept or reject the extracted nutrient values
+2. Modify the extracted values if needed
+3. Propose a new bounding box for the nutrition area, which will be used for cropping the image
+
+This bounding box information is stored with the insight data and used for visualization and future image cropping.
 
 [^other_nutrient_detection]: Using a fixed set of classes is not the best approach when we have many classes. It however allows us to use LayoutLM architecture, which is very performant for this task, even when the nutrition table is hard to read due to packaging deformations or alterations. To detect the long-tail of nutrients, approaches using graph-based approach, where we would map a nutrient mention to its value, could be explored in the future.
 

--- a/robotoff/app/core.py
+++ b/robotoff/app/core.py
@@ -370,6 +370,7 @@ def save_annotation(
     data: Optional[dict] = None,
     auth: Optional[OFFAuthentication] = None,
     trusted_annotator: bool = False,
+    bounding_box: Optional[dict] = None,
 ) -> AnnotationResult:
     """Saves annotation either by using a single response as ground truth or
     by using several responses.
@@ -394,8 +395,9 @@ def save_annotation(
     :param auth: User authentication data, it is expected to be None if
         `trusted_annotator=False` (=anonymous vote)
     :param trusted_annotator: Defines whether the given annotation comes from
-    an authoritative source (e.g. a trusted user), ot whether the annotation
-    should be subject to the voting system.
+      an authoritative source (e.g. a trusted user), ot whether the annotation
+      should be subject to the voting system.
+    :param bounding_box: Optional bounding box coordinates for nutrition insights
     """
     try:
         insight: Union[ProductInsight, None] = ProductInsight.get_by_id(insight_id)
@@ -407,6 +409,10 @@ def save_annotation(
 
     if insight.annotation is not None:
         return ALREADY_ANNOTATED_RESULT
+
+    # Update bounding box if provided
+    if bounding_box is not None and trusted_annotator:
+        insight.bounding_box = bounding_box
 
     # We use AnnotationVote mechanism to save annotation = -1 (ignore) for
     # authenticated users, so that it's not returned again to the user

--- a/robotoff/images.py
+++ b/robotoff/images.py
@@ -295,3 +295,20 @@ def delete_images(product_id: ProductIdentifier, image_ids: list[str]):
         deleted_embeddings_total,
         deleted_logos_total,
     )
+
+
+def crop_nutrition_image(image_path: str, bounding_box: dict) -> Image.Image:
+    """Crop an image using the nutrition bounding box.
+
+    :param image_path: Path to the image file to crop
+    :param bounding_box: Dictionary with x_min, y_min, x_max, y_max coordinates
+    :return: Cropped image
+    """
+    img = Image.open(image_path)
+    crop_box = (
+        bounding_box["x_min"],
+        bounding_box["y_min"],
+        bounding_box["x_max"],
+        bounding_box["y_max"],
+    )
+    return img.crop(crop_box)

--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -1564,7 +1564,25 @@ class NutrientExtractionImporter(InsightImporter):
 
         for prediction in predictions:
             if cls.keep_prediction(product, list(prediction.data["nutrients"].keys())):
-                yield ProductInsight(**prediction.to_dict())
+                # Create dictionary from prediction
+                prediction_data = prediction.to_dict()
+
+                # Store bounding box directly in the insight model field
+                bounding_box = None
+                if "bounding_box" in prediction.data:
+                    # Convert tuple to dictionary format expected by the database
+                    y_min, x_min, y_max, x_max = prediction.data["bounding_box"]
+                    bounding_box = {
+                        "y_min": y_min,
+                        "x_min": x_min,
+                        "y_max": y_max,
+                        "x_max": x_max,
+                    }
+
+                # Create the insight with the bounding box field
+                insight = ProductInsight(**prediction_data)
+                insight.bounding_box = bounding_box
+                yield insight
 
     @staticmethod
     def keep_prediction(product: Product | None, nutrients_keys: list[str]) -> bool:


### PR DESCRIPTION
### What
- Added bounding box computation for nutrition extraction using OCR word positions
- Added bounding_box column to both prediction and product_insight tables
- Included bounding box in nutrition extraction insights
- Created an endpoint to allow users to propose a new bounding box during validation
- Modified the image cropping function to use the stored bounding box information

## Implementation Details

- Enhanced `NutrientPrediction` and `NutritionExtractionPrediction` classes to include bounding box information
- Added `compute_bounding_box` function to calculate the overall bounding box from individual word positions
- Updated the `NutrientExtractionImporter` to include bounding box data in generated insights
- Added support for updating bounding box through annotation in `NutrientExtractionAnnotator`
- Implemented tests for bounding box computation and cropping functionality

## How This Improves User Experience

This enhancement significantly improves the visualization of nutrition extraction results during validation. Previously, the bounding box was only used internally for cropping, but was not exposed in the insight data. Now, users validating nutrition insights can see exactly which part of the image was analyzed, and even propose corrections to the bounding box if needed.

### Fixes 
Add bounding box to nutrition extraction [#1539](https://github.com/openfoodfacts/robotoff/issues/1539)


