### PR TITLE
feat: Implement auto-rotation for selected images using Google Cloud Vision predictions

### DIFF
--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -1885,8 +1885,8 @@ class ImageOrientationImporter(InsightImporter):
                     and confidence >= 0.95
                 ):
                     insight = ProductInsight(**prediction.to_dict())
-                    insight.automatic_processing = True
-                    insight.data["confidence"] = confidence
+                    insight.automatic_processing = False
+                    insight.confidence = confidence
                     yield insight
 
 

--- a/tests/integration/insights/test_importer.py
+++ b/tests/integration/insights/test_importer.py
@@ -1,10 +1,12 @@
 import pytest
 
 from robotoff.insights.importer import (
+    ImageOrientationImporter,
     NutritionImageImporter,
     import_product_predictions,
 )
 from robotoff.models import Prediction as PredictionModel
+from robotoff.products import Product
 from robotoff.types import Prediction, PredictionType, ProductIdentifier, ServerType
 
 from ..models_utils import (
@@ -146,19 +148,6 @@ class TestImageOrientationImporter:
         return _factory
 
     def test_import_image_orientation_prediction(self, prediction_factory, peewee_db):
-        # Original implementation - this doesn't work because the factory
-        # directly creates the record in the database, so import_product_predictions
-        # finds it as existing and doesn't import it.
-        """
-        prediction = prediction_factory()
-
-        imported, deleted = import_product_predictions(
-            prediction.barcode, prediction.server_type, [prediction]
-        )
-        """
-
-        # TEMPORARY FIX: Create a factory prediction to get values, but delete it
-        # and create a new Prediction object that isn't in the database yet
         factory_prediction = prediction_factory()
 
         # Get the data from the factory prediction
@@ -193,6 +182,89 @@ class TestImageOrientationImporter:
         assert db_prediction.data["orientation"] == "right"
         assert db_prediction.data["rotation"] == 270
         assert db_prediction.data["count"]["right"] == 19
+
+    def test_generate_insight_with_confidence(self, prediction_factory, mocker):
+        factory_prediction = prediction_factory(
+            count={"up": 1, "right": 19}  # 95% confidence for "right"
+        )
+
+        factory_prediction.delete_instance()
+
+        prediction_data = {
+            "barcode": factory_prediction.barcode,
+            "server_type": factory_prediction.server_type,
+            "type": factory_prediction.type,
+            "source_image": factory_prediction.source_image,
+            "data": factory_prediction.data,
+            "value_tag": factory_prediction.value_tag,
+        }
+
+        prediction = Prediction(**prediction_data)
+
+        # Mock the is_selected_image function to return True
+        mocker.patch("robotoff.insights.importer.is_selected_image", return_value=True)
+
+        # Create a product
+        product = Product({"code": prediction.barcode, "images": {"1": {"imgid": "1"}}})
+
+        # Generate candidates
+        product_id = ProductIdentifier(prediction.barcode, prediction.server_type)
+        candidates = list(
+            ImageOrientationImporter.generate_candidates(
+                product,
+                [prediction],
+                product_id,
+            )
+        )
+
+        # Verify that one candidate was generated
+        assert len(candidates) == 1
+
+        # Verify properties of the candidate
+        candidate = candidates[0]
+        # Calculate expected confidence
+        total = sum(prediction.data["count"].values())
+        expected_confidence = prediction.data["count"]["right"] / total
+
+        assert candidate.automatic_processing is False
+        assert candidate.confidence == expected_confidence
+        assert candidate.data["rotation"] == 270
+
+    def test_image_orientation_settings(self, prediction_factory, mocker):
+        factory_prediction = prediction_factory(count={"up": 1, "right": 19})
+
+        pred_data = {
+            "barcode": factory_prediction.barcode,
+            "server_type": factory_prediction.server_type,
+            "type": factory_prediction.type,
+            "source_image": factory_prediction.source_image,
+            "data": factory_prediction.data,
+            "value_tag": factory_prediction.value_tag,
+        }
+
+        factory_prediction.delete_instance()
+
+        prediction = Prediction(**pred_data)
+
+        product = Product({"code": prediction.barcode, "images": {"1": {"imgid": "1"}}})
+        mocker.patch("robotoff.insights.importer.is_selected_image", return_value=True)
+
+        candidates = list(
+            ImageOrientationImporter.generate_candidates(
+                product,
+                [prediction],
+                ProductIdentifier(
+                    barcode=prediction.barcode, server_type=prediction.server_type
+                ),
+            )
+        )
+
+        assert len(candidates) == 1
+        assert candidates[0].automatic_processing is False
+
+        # Verify confidence is set correctly (right / total words)
+        expected_confidence = 19 / 20
+        assert candidates[0].confidence == expected_confidence
 
 
 def test_import_product_predictions():

--- a/tests/integration/insights/test_importer.py
+++ b/tests/integration/insights/test_importer.py
@@ -146,9 +146,37 @@ class TestImageOrientationImporter:
         return _factory
 
     def test_import_image_orientation_prediction(self, prediction_factory, peewee_db):
+        # Original implementation - this doesn't work because the factory
+        # directly creates the record in the database, so import_product_predictions
+        # finds it as existing and doesn't import it.
+        """
         prediction = prediction_factory()
 
-        # Import the prediction
+        imported, deleted = import_product_predictions(
+            prediction.barcode, prediction.server_type, [prediction]
+        )
+        """
+
+        # TEMPORARY FIX: Create a factory prediction to get values, but delete it
+        # and create a new Prediction object that isn't in the database yet
+        factory_prediction = prediction_factory()
+
+        # Get the data from the factory prediction
+        pred_data = {
+            "barcode": factory_prediction.barcode,
+            "server_type": factory_prediction.server_type,
+            "type": factory_prediction.type,
+            "source_image": factory_prediction.source_image,
+            "data": factory_prediction.data,
+            "value_tag": factory_prediction.value_tag,
+        }
+
+        # Delete the factory-created record from the database
+        factory_prediction.delete_instance()
+
+        # Create a new Prediction object that isn't in the database
+        prediction = Prediction(**pred_data)
+
         imported, deleted = import_product_predictions(
             prediction.barcode, prediction.server_type, [prediction]
         )


### PR DESCRIPTION
**Signed-off-by**: Areeb Ahmed [areebshariff@acm.org](mailto:areebshariff@acm.org)

## Description

This PR adds automatic rotation for selected images (**front**, **nutrition**, **ingredients**, and **packaging**) based on Google Cloud Vision OCR predictions.

**Key Changes**

• Introduced `ImageOrientationImporter` to process orientation predictions, filtering for selected images with high confidence (≥95%)
• Added `ImageOrientationAnnotator` to perform image rotation via the Product Opener API
• Ensured correct handling of bounding box coordinates during image rotation
• Added unit and integration tests

This addresses issue #971, reflecting the updated requirement to apply rotation only to selected images rather than all raw images.