### PR TITLE
feat: improve image orientation insights

### DIFF
--- a/i18n/robotoff.pot
+++ b/i18n/robotoff.pot
@@ -35,3 +35,7 @@ msgstr ""
 # Question that appears for logged-in users on the Web and Android
 msgid "Does the product have this packaging element?"
 msgstr ""
+
+# Question that appears for logged-in users on the Web and Android
+msgid "Is this image rotated with the following orientation?"
+msgstr ""

--- a/robotoff/insights/annotate.py
+++ b/robotoff/insights/annotate.py
@@ -968,7 +968,7 @@ class ImageOrientationAnnotator(InsightAnnotator):
             return OUTDATED_DATA_RESULT
 
         # This is the key of the selected image that we want to rotate
-        selected_key = typing.cast(str, insight.value)
+        selected_key = typing.cast(str, insight.data["image_key"])
 
         if selected_key not in product_images:
             logger.warning(
@@ -986,10 +986,10 @@ class ImageOrientationAnnotator(InsightAnnotator):
         if all(k in image_data for k in ("x1", "y1", "x2", "y2")):
             # Check for uncropped images (coordinates = -1)
             if not (
-                image_data["x1"] == "-1"
-                and image_data["y1"] == "-1"
-                and image_data["x2"] == "-1"
-                and image_data["y2"] == "-1"
+                image_data["x1"] in ("-1", -1)
+                and image_data["y1"] in ("-1", -1)
+                and image_data["x2"] in ("-1", -1)
+                and image_data["y2"] in ("-1", -1)
             ):
                 y1 = float(image_data["y1"])
                 x1 = float(image_data["x1"])

--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -1848,7 +1848,7 @@ class ImageOrientationImporter(InsightImporter):
     ) -> bool:
         # Two insights conflict if they refer to the same selected image
         return (
-            candidate.value == reference.value
+            candidate.data["image_key"] == reference.data["image_key"]
             and candidate.source_image == reference.source_image
         )
 
@@ -1893,7 +1893,9 @@ class ImageOrientationImporter(InsightImporter):
                 ):
                     # The `value` field represents the key of the selected image
                     insight_dict = prediction.to_dict()
-                    insight_dict["value"] = key
+                    insight_dict["data"]["image_key"] = key
+                    insight_dict["data"]["image_rev"] = image_data["rev"]
+                    insight_dict["value_tag"] = orientation
                     insight = ProductInsight(**insight_dict)
                     insight.automatic_processing = False
                     insight.confidence = confidence

--- a/robotoff/insights/question.py
+++ b/robotoff/insights/question.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from robotoff import settings
 from robotoff.models import ProductInsight
-from robotoff.off import generate_image_url
+from robotoff.off import generate_image_path, generate_image_url
 from robotoff.products import get_product
 from robotoff.taxonomy import Taxonomy, TaxonomyType, get_taxonomy
 from robotoff.types import InsightType, JSONType, ProductIdentifier
@@ -121,11 +121,11 @@ class AddBinaryQuestion(Question):
     :param value: the suggested answer to the question
     :param insight: the insight used to generate the question
     :param ref_image_url: the URL of a reference image, used to display the
-    image of the logo for `label` insights, optional
+        image of the logo for `label` insights, optional
     :param source_image_url: the URL of the image from where the insight was
-    extracted from, optional
+        extracted from, optional
     :param value_tag: The `value_tag` that is going to be sent to Product
-    Opener if the insight is validated, optional
+        Opener if the insight is validated, optional
     """
 
     def __init__(
@@ -395,6 +395,30 @@ class UPCImageQuestionFormatter(QuestionFormatter):
             source_image_url = settings.BaseURLProvider.image_url(
                 product_id.server_type, get_display_image(insight.source_image)
             )
+
+        return AddBinaryQuestion(
+            question=localized_question,
+            value=insight.value_tag,
+            insight=insight,
+            source_image_url=source_image_url,
+        )
+
+
+class ImageOrientationQuestionFormatter(QuestionFormatter):
+    question = "Is this image rotated with the following orientation?"
+
+    def format_question(self, insight: ProductInsight, lang: str) -> Question:
+        localized_question = self.translation_store.gettext(lang, self.question)
+
+        server_type = insight.get_product_id().server_type
+
+        image_key = insight.data["image_key"]
+        image_rev = insight.data["image_rev"]
+
+        image_path = generate_image_path(
+            insight.get_product_id(), f"{image_key}.{image_rev}.400"
+        )
+        source_image_url = settings.BaseURLProvider.image_url(server_type, image_path)
 
         return AddBinaryQuestion(
             question=localized_question,

--- a/robotoff/settings.py
+++ b/robotoff/settings.py
@@ -100,6 +100,13 @@ class BaseURLProvider(object):
 
     @staticmethod
     def image_url(server_type: ServerType, image_path: str) -> str:
+        """Generate the URL of an Open Food Facts image.
+
+        :param server_type: The server type (e.g., ServerType.off).
+        :param image_path: The path to the image (e.g.,
+            "/002/604/035/3579/front_en.21.400.jpg").
+        :return: The full URL of the image.
+        """
         prefix = BaseURLProvider._get_url(
             prefix="images", base_domain=server_type.get_base_domain()
         )

--- a/tests/integration/insights/test_annotate.py
+++ b/tests/integration/insights/test_annotate.py
@@ -360,10 +360,13 @@ class TestImageOrientationAnnotator:
 
         insight = ProductInsightFactory(
             type="image_orientation",
+            value_tag="right",
             data={
                 "orientation": "right",
                 "rotation": 270,
                 "count": {"up": 1, "right": 19},
+                "image_rev": "10",
+                "image_key": "front_fr",
             },
             source_image="/1.jpg",
         )
@@ -385,10 +388,13 @@ class TestImageOrientationAnnotator:
 
         insight = ProductInsightFactory(
             type="image_orientation",
+            value_tag="right",
             data={
                 "orientation": "right",
                 "rotation": 270,
                 "count": {"up": 1, "right": 19},
+                "image_key": "front_fr",
+                "image_rev": "10",
             },
             source_image="/1.jpg",
         )
@@ -412,6 +418,7 @@ class TestImageOrientationAnnotator:
                     "y1": "200",
                     "x2": "600",
                     "y2": "800",
+                    "rev": "7",
                     "sizes": {"full": {"h": 1000, "w": 800}},
                 },
             }
@@ -427,11 +434,13 @@ class TestImageOrientationAnnotator:
             barcode=barcode,
             server_type=server_type,
             type="image_orientation",
-            value="ingredients_it",
+            value="right",
             data={
                 "orientation": "right",
                 "rotation": 270,
                 "count": {"up": 1, "right": 19},
+                "image_key": "ingredients_it",
+                "image_rev": "7",
             },
             source_image=generate_image_path(product_id, "1"),
         )
@@ -459,20 +468,25 @@ class TestImageOrientationAnnotator:
             insight_id=insight.id,
         )
 
-    def test_uncropped_image_handling(self, mock_get_product, mock_select_rotate_image):
+    @pytest.mark.parametrize(
+        "selected_image_data",
+        [
+            # Uncropped selected images can have "-1" or -1 (string or int) for
+            # coordinates
+            {"imgid": "1", "rev": "2", "x1": "-1", "y1": "-1", "x2": "-1", "y2": "-1"},
+            {"imgid": "1", "rev": "2", "x1": -1, "y1": -1, "x2": -1, "y2": -1},
+        ],
+    )
+    def test_uncropped_image_handling(
+        self, selected_image_data, mock_get_product, mock_select_rotate_image
+    ):
         mock_get_product.return_value = {
             "images": {
                 "1": {
                     "imgid": "1",
                     "sizes": {"full": {"h": 1000, "w": 800}},
                 },
-                "front_en": {
-                    "imgid": "1",
-                    "x1": "-1",  # Uncropped image
-                    "y1": "-1",
-                    "x2": "-1",
-                    "y2": "-1",
-                },
+                "front_en": selected_image_data,
             }
         }
 
@@ -483,11 +497,13 @@ class TestImageOrientationAnnotator:
             barcode=barcode,
             server_type=server_type,
             type="image_orientation",
-            value="front_en",
+            value_tag="right",
             data={
                 "orientation": "right",
                 "rotation": 270,
                 "count": {"up": 1, "right": 19},
+                "image_rev": "2",
+                "image_key": "front_en",
             },
             source_image="/1.jpg",
         )

--- a/tests/integration/insights/test_importer.py
+++ b/tests/integration/insights/test_importer.py
@@ -205,7 +205,7 @@ class TestImageOrientationImporter:
         product = Product(
             {
                 "code": prediction.barcode,
-                "images": {"1": {"imgid": "1"}, "front_it": {"imgid": "1"}},
+                "images": {"1": {"imgid": "1"}, "front_it": {"imgid": "1", "rev": "3"}},
             }
         )
 
@@ -224,7 +224,8 @@ class TestImageOrientationImporter:
 
         # Verify properties of the candidate
         candidate = candidates[0]
-        assert candidate.value == "front_it"
+        assert candidate.data["image_key"] == "front_it"
+        assert candidate.data["image_rev"] == "3"
         # Calculate expected confidence
         total = sum(prediction.data["count"].values())
         expected_confidence = prediction.data["count"]["right"] / total
@@ -255,9 +256,9 @@ class TestImageOrientationImporter:
                 "images": {
                     "1": {"imgid": "1"},
                     "2": {"imgid": "2"},
-                    "nutrition_fr": {"imgid": "1"},
-                    "front_it": {"imgid": "1"},
-                    "front_en": {"imgid": "2"},
+                    "nutrition_fr": {"imgid": "1", "rev": "2"},
+                    "front_it": {"imgid": "1", "rev": "3"},
+                    "front_en": {"imgid": "2", "rev": "4"},
                 },
             }
         )
@@ -272,13 +273,17 @@ class TestImageOrientationImporter:
         )
 
         assert len(candidates) == 2
-        assert candidates[0].value == "nutrition_fr"
+        assert candidates[0].value_tag == "right"
+        assert candidates[0].data["image_key"] == "nutrition_fr"
+        assert candidates[0].data["image_rev"] == "2"
         assert candidates[0].automatic_processing is False
         # Verify confidence is set correctly (right / total words)
         expected_confidence = 19 / 20
         assert candidates[0].confidence == expected_confidence
 
-        assert candidates[1].value == "front_it"
+        assert candidates[1].value_tag == "right"
+        assert candidates[1].data["image_key"] == "front_it"
+        assert candidates[1].data["image_rev"] == "3"
 
 
 def test_import_product_predictions():

--- a/tests/unit/insights/test_importer.py
+++ b/tests/unit/insights/test_importer.py
@@ -2019,176 +2019,201 @@ class TestImportInsightsForProducts:
         assert not import_insights_mock.called
 
 
-def test_image_orientation_get_type():
-    assert ImageOrientationImporter.get_type() == InsightType.image_orientation
+class TestImageOrientationImporter:
+    def test_image_orientation_get_type(self):
+        assert ImageOrientationImporter.get_type() == InsightType.image_orientation
 
+    def test_image_orientation_get_required_prediction_types(self):
+        assert ImageOrientationImporter.get_required_prediction_types() == {
+            PredictionType.image_orientation
+        }
 
-def test_image_orientation_get_required_prediction_types():
-    assert ImageOrientationImporter.get_required_prediction_types() == {
-        PredictionType.image_orientation
-    }
-
-
-def test_image_orientation_is_conflicting_insight():
-    candidate = ProductInsight(
-        barcode=DEFAULT_BARCODE,
-        type=InsightType.image_orientation,
-        source_image="/1.jpg",
-    )
-
-    # Conflicting insight (same source_image)
-    reference = ProductInsight(
-        barcode=DEFAULT_BARCODE,
-        type=InsightType.image_orientation,
-        source_image="/1.jpg",
-    )
-    assert ImageOrientationImporter.is_conflicting_insight(candidate, reference) is True
-
-    # Non-conflicting insight (different source_image)
-    reference = ProductInsight(
-        barcode=DEFAULT_BARCODE,
-        type=InsightType.image_orientation,
-        source_image="/2.jpg",
-    )
-    assert (
-        ImageOrientationImporter.is_conflicting_insight(candidate, reference) is False
-    )
-
-
-@pytest.mark.parametrize(
-    "orientation,rotation,counts,image_data,selected,expected_candidates",
-    [
-        # Upright image - should not generate candidate
-        (
-            "up",
-            0,
-            {"up": 10, "right": 0},
-            {"1": {"imgid": "1"}, "front_en": {"imgid": "1"}},
-            True,
-            0,
-        ),
-        # Low confidence - should not generate candidate
-        (
-            "right",
-            270,
-            {"up": 5, "right": 4},
-            {"1": {"imgid": "1"}, "front_en": {"imgid": "1"}},
-            True,
-            0,
-        ),
-        # Not selected image - should not generate candidate
-        (
-            "right",
-            270,
-            {"up": 0, "right": 10},
-            # Default source image is "1"
-            {"1": {"imgid": "1"}, "2": {"imgid": "2"}, "front_en": {"imgid": "2"}},
-            False,
-            0,
-        ),
-        # Valid case - should generate candidate
-        # (high confidence, selected image, needs rotation)
-        (
-            "right",
-            270,
-            {"up": 0, "right": 20},
-            {"1": {"imgid": "1"}, "front_en": {"imgid": "1"}},
-            True,
-            1,
-        ),
-        # Valid case with mixed orientation counts but still high confidence
-        # Most words are oriented right
-        (
-            "right",
-            270,
-            {"up": 1, "right": 19},
-            {"1": {"imgid": "1"}, "front_en": {"imgid": "1"}},
-            True,
-            1,
-        ),
-        # Edge case - exactly 95% confidence
-        (
-            "right",
-            270,
-            {"up": 1, "right": 19, "left": 0},
-            {"1": {"imgid": "1"}, "front_en": {"imgid": "1"}},
-            True,
-            1,
-        ),
-        # Edge case - just below 95% confidence
-        (
-            "right",
-            270,
-            {"up": 2, "right": 18, "left": 0},
-            {"1": {"imgid": "1"}, "front_en": {"imgid": "1"}},
-            True,
-            0,
-        ),
-        # The same image is selected for multiple keys (nutrition, ingredients,
-        # front,...)
-        # We should generate as many candidates as keys
-        (
-            "right",
-            270,
-            {"up": 0, "right": 20},
-            {
-                "1": {"imgid": "1"},
-                "front_fr": {"imgid": "1"},
-                "nutrition_fr": {"imgid": "1"},
-                "ingredients_fr": {"imgid": "1"},
-                "packaging_fr": {"imgid": "1"},
-            },
-            True,
-            4,
-        ),
-    ],
-)
-def test_image_orientation_generate_candidates(
-    mocker,
-    orientation: str,
-    rotation: int,
-    counts: JSONType,
-    image_data: JSONType,
-    selected: bool,
-    expected_candidates: int,
-):
-    # Mock is_selected_image function
-    mocker.patch("robotoff.insights.importer.is_selected_image", return_value=selected)
-
-    # Calculate confidence for verification if needed
-    total = sum(counts.values())
-    confidence = counts.get(orientation, 0) / total if total > 0 else 0
-
-    # Create prediction with given parameters
-    prediction = Prediction(
-        barcode=DEFAULT_BARCODE,
-        type=PredictionType.image_orientation,
-        data={
-            "orientation": orientation,
-            "rotation": rotation,
-            "count": counts,
-        },
-        server_type=ServerType.off,
-        source_image=DEFAULT_SOURCE_IMAGE,
-    )
-
-    # Create product
-    product = Product({"code": DEFAULT_BARCODE, "images": image_data})
-
-    # Generate candidates
-    candidates = list(
-        ImageOrientationImporter.generate_candidates(
-            product,
-            [prediction],
-            DEFAULT_PRODUCT_ID,
+    def test_image_orientation_is_conflicting_insight(self):
+        candidate = ProductInsight(
+            barcode=DEFAULT_BARCODE,
+            type=InsightType.image_orientation,
+            data={"image_key": "front_en"},
+            source_image="/1.jpg",
         )
+
+        # Conflicting insight (same source_image)
+        reference = ProductInsight(
+            barcode=DEFAULT_BARCODE,
+            type=InsightType.image_orientation,
+            data={"image_key": "front_en"},
+            source_image="/1.jpg",
+        )
+        assert (
+            ImageOrientationImporter.is_conflicting_insight(candidate, reference)
+            is True
+        )
+
+        # Non-conflicting insight (different source_image)
+        reference_2 = ProductInsight(
+            barcode=DEFAULT_BARCODE,
+            type=InsightType.image_orientation,
+            data={"image_key": "front_en"},
+            source_image="/2.jpg",
+        )
+        # Non-conflicting insight (different image key)
+        reference_3 = ProductInsight(
+            barcode=DEFAULT_BARCODE,
+            type=InsightType.image_orientation,
+            data={"image_key": "front_it"},
+            source_image="/1.jpg",
+        )
+        assert (
+            ImageOrientationImporter.is_conflicting_insight(candidate, reference_2)
+            is False
+        )
+        assert (
+            ImageOrientationImporter.is_conflicting_insight(candidate, reference_3)
+            is False
+        )
+
+    @pytest.mark.parametrize(
+        "orientation,rotation,counts,image_data,selected,expected_candidates",
+        [
+            # Upright image - should not generate candidate
+            (
+                "up",
+                0,
+                {"up": 10, "right": 0},
+                {"1": {"imgid": "1"}, "front_en": {"imgid": "1", "rev": "10"}},
+                True,
+                0,
+            ),
+            # Low confidence - should not generate candidate
+            (
+                "right",
+                270,
+                {"up": 5, "right": 4},
+                {"1": {"imgid": "1"}, "front_en": {"imgid": "1", "rev": "10"}},
+                True,
+                0,
+            ),
+            # Not selected image - should not generate candidate
+            (
+                "right",
+                270,
+                {"up": 0, "right": 10},
+                # Default source image is "1"
+                {
+                    "1": {"imgid": "1"},
+                    "2": {"imgid": "2"},
+                    "front_en": {"imgid": "2", "rev": "10"},
+                },
+                False,
+                0,
+            ),
+            # Valid case - should generate candidate
+            # (high confidence, selected image, needs rotation)
+            (
+                "right",
+                270,
+                {"up": 0, "right": 20},
+                {"1": {"imgid": "1"}, "front_en": {"imgid": "1", "rev": "10"}},
+                True,
+                1,
+            ),
+            # Valid case with mixed orientation counts but still high confidence
+            # Most words are oriented right
+            (
+                "right",
+                270,
+                {"up": 1, "right": 19},
+                {"1": {"imgid": "1"}, "front_en": {"imgid": "1", "rev": "10"}},
+                True,
+                1,
+            ),
+            # Edge case - exactly 95% confidence
+            (
+                "right",
+                270,
+                {"up": 1, "right": 19, "left": 0},
+                {"1": {"imgid": "1"}, "front_en": {"imgid": "1", "rev": "10"}},
+                True,
+                1,
+            ),
+            # Edge case - just below 95% confidence
+            (
+                "right",
+                270,
+                {"up": 2, "right": 18, "left": 0},
+                {"1": {"imgid": "1"}, "front_en": {"imgid": "1", "rev": "10"}},
+                True,
+                0,
+            ),
+            # The same image is selected for multiple keys (nutrition, ingredients,
+            # front,...)
+            # We should generate as many candidates as keys
+            (
+                "right",
+                270,
+                {"up": 0, "right": 20},
+                {
+                    "1": {"imgid": "1"},
+                    "front_fr": {"imgid": "1", "rev": "10"},
+                    "nutrition_fr": {"imgid": "1", "rev": "10"},
+                    "ingredients_fr": {"imgid": "1", "rev": "10"},
+                    "packaging_fr": {"imgid": "1", "rev": "10"},
+                },
+                True,
+                4,
+            ),
+        ],
     )
+    def test_image_orientation_generate_candidates(
+        self,
+        mocker,
+        orientation: str,
+        rotation: int,
+        counts: JSONType,
+        image_data: JSONType,
+        selected: bool,
+        expected_candidates: int,
+    ):
+        # Mock is_selected_image function
+        mocker.patch(
+            "robotoff.insights.importer.is_selected_image", return_value=selected
+        )
 
-    # Verify number of candidates
-    assert len(candidates) == expected_candidates
+        # Calculate confidence for verification if needed
+        total = sum(counts.values())
+        confidence = counts.get(orientation, 0) / total if total > 0 else 0
 
-    if expected_candidates > 0:
-        candidate = candidates[0]
-        assert candidate.automatic_processing is False  # Should be False intially
-        assert candidate.confidence == confidence
-        assert candidate.data["rotation"] == rotation
+        # Create prediction with given parameters
+        prediction = Prediction(
+            barcode=DEFAULT_BARCODE,
+            type=PredictionType.image_orientation,
+            data={
+                "orientation": orientation,
+                "rotation": rotation,
+                "count": counts,
+            },
+            server_type=ServerType.off,
+            source_image=DEFAULT_SOURCE_IMAGE,
+        )
+
+        # Create product
+        product = Product({"code": DEFAULT_BARCODE, "images": image_data})
+
+        # Generate candidates
+        candidates = list(
+            ImageOrientationImporter.generate_candidates(
+                product,
+                [prediction],
+                DEFAULT_PRODUCT_ID,
+            )
+        )
+
+        # Verify number of candidates
+        assert len(candidates) == expected_candidates
+
+        if expected_candidates > 0:
+            candidate = candidates[0]
+            assert candidate.automatic_processing is False  # Should be False intially
+            assert candidate.confidence == confidence
+            assert candidate.data["rotation"] == rotation
+            assert "image_key" in candidate.data
+            assert "image_rev" in candidate.data

--- a/tests/unit/insights/test_question.py
+++ b/tests/unit/insights/test_question.py
@@ -6,6 +6,7 @@ from openfoodfacts.images import split_barcode
 
 from robotoff.insights.question import (
     CategoryQuestionFormatter,
+    ImageOrientationQuestionFormatter,
     LabelQuestionFormatter,
     Question,
     generate_selected_images,
@@ -13,7 +14,7 @@ from robotoff.insights.question import (
 )
 from robotoff.models import ProductInsight
 from robotoff.settings import TEST_DATA_DIR
-from robotoff.types import InsightType, ProductIdentifier, ServerType
+from robotoff.types import InsightType, JSONType, ProductIdentifier, ServerType
 from robotoff.utils.i18n import TranslationStore
 
 
@@ -97,8 +98,10 @@ def generate_insight(
     value_tag: Optional[str] = None,
     add_source_image: bool = False,
     server_type: ServerType = ServerType.off,
+    data: JSONType | None = None,
 ) -> ProductInsight:
     barcode = "1111111111"
+    data = data or {}
     return ProductInsight(
         type=insight_type,
         value=value,
@@ -107,6 +110,7 @@ def generate_insight(
         source_image=(
             f"/{'/'.join(split_barcode(barcode))}/1.jpg" if add_source_image else None
         ),
+        data=data,
         server_type=server_type.name,
     )
 
@@ -227,3 +231,28 @@ def test_label_question_formatter(
     if ref_image_url is not None:
         expected_dict["ref_image_url"] = ref_image_url
     assert question.serialize() == expected_dict
+
+
+class TestImageOrientationQuestionFormatter:
+    def test_format_question(self, mocker, translation_store):
+        insight = generate_insight(
+            insight_type=InsightType.image_orientation.name,
+            value_tag="right",
+            add_source_image=True,
+            server_type=ServerType.off,
+            data={"image_key": "front_fr", "image_rev": "10"},
+        )
+        question = ImageOrientationQuestionFormatter(translation_store).format_question(
+            insight, "en"
+        )
+        assert isinstance(question, Question)
+        assert question.serialize() == {
+            "barcode": insight.barcode,
+            "type": "add-binary",
+            "value": "right",
+            "question": "Is this image rotated with the following orientation?",
+            "insight_id": str(insight.id),
+            "insight_type": InsightType.image_orientation.name,
+            "server_type": ServerType.off.name,
+            "source_image_url": "https://images.openfoodfacts.net/images/products/000/111/111/1111/front_fr.10.400.jpg",
+        }


### PR DESCRIPTION
- use `insight.value_tag` to store the orientation
- save the image key and rev in `insight.data`
- create a question formatter to be able to use the insight type on Hunger Games