### PR TITLE
feat: apply image rotation insights automatically

### DIFF
--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -1910,7 +1910,10 @@ class ImageOrientationImporter(InsightImporter):
                     insight_dict["data"]["image_rev"] = image_data["rev"]
                     insight_dict["value_tag"] = orientation
                     insight = ProductInsight(**insight_dict)
-                    insight.automatic_processing = False
+                    # We process automatically the image if we have more than 10 words
+                    # A manual inspection showed that all the false positive cases
+                    # were due to images with very few words
+                    insight.automatic_processing = total_words >= 10
                     insight.confidence = confidence
                     yield insight
 

--- a/tests/integration/insights/test_importer.py
+++ b/tests/integration/insights/test_importer.py
@@ -230,12 +230,15 @@ class TestImageOrientationImporter:
         total = sum(prediction.data["count"].values())
         expected_confidence = prediction.data["count"]["right"] / total
 
-        assert candidate.automatic_processing is False
+        assert candidate.value_tag == "right"
+        # More than 10 words, automatic processing is enabled
+        assert candidate.automatic_processing is True
         assert candidate.confidence == expected_confidence
         assert candidate.data["rotation"] == 270
 
     def test_image_orientation_settings(self, prediction_factory, mocker):
-        factory_prediction = prediction_factory(count={"up": 1, "right": 19})
+        # Less than 10 words, automatic processing is disabled
+        factory_prediction = prediction_factory(count={"right": 7})
 
         pred_data = {
             "barcode": factory_prediction.barcode,
@@ -276,10 +279,11 @@ class TestImageOrientationImporter:
         assert candidates[0].value_tag == "right"
         assert candidates[0].data["image_key"] == "nutrition_fr"
         assert candidates[0].data["image_rev"] == "2"
+        # Verify that the candidate is not automatically processed
+        # as it has less than 10 words
         assert candidates[0].automatic_processing is False
         # Verify confidence is set correctly (right / total words)
-        expected_confidence = 19 / 20
-        assert candidates[0].confidence == expected_confidence
+        assert candidates[0].confidence == 1.0
 
         assert candidates[1].value_tag == "right"
         assert candidates[1].data["image_key"] == "front_it"

--- a/tests/unit/insights/test_importer.py
+++ b/tests/unit/insights/test_importer.py
@@ -2257,7 +2257,7 @@ class TestImageOrientationImporter:
 
         if expected_candidates > 0:
             candidate = candidates[0]
-            assert candidate.automatic_processing is False  # Should be False intially
+            assert candidate.automatic_processing is (total >= 10)
             assert candidate.confidence == confidence
             assert candidate.data["rotation"] == rotation
             assert "image_key" in candidate.data


### PR DESCRIPTION
If there are more than 10 words detected and 95% of all words of the original image have the same orientation, we now apply automatically the image orientation insight.
If the 10 words condition is not respected (but the 0.95 threshold is), we let users validate the insight on Hunger Games.