### PR TITLE
fix: fix bug in `extract_ingredients_job` function

### DIFF
--- a/tests/integration/workers/tasks/test_import_image.py
+++ b/tests/integration/workers/tasks/test_import_image.py
@@ -258,3 +258,83 @@ def test_extract_ingredients_job_existing_image_prediction(mocker, peewee_db):
         assert import_insights.call_args.kwargs == {
             "server_type": ServerType.off,
         }
+
+
+def test_extract_ingredients_job_product_opener_api_failed(mocker, peewee_db):
+    full_text = "Best product ever!\ningredients: water, salt, sugar."
+    entities = [
+        IngredientPredictionAggregatedEntity(
+            start=19,
+            end=51,
+            raw_end=51,
+            score=0.9,
+            text="water, salt, sugar.",
+            lang=LanguagePrediction(lang="en", confidence=0.9),
+            bounding_box=(0, 0, 100, 100),
+        )
+    ]
+    ingredient_list_mocker = mocker.patch(
+        "robotoff.workers.tasks.import_image.ingredient_list"
+    )
+
+    # make parse_ingredients raise a RuntimeError
+    parse_ingredients_mocker = mocker.patch(
+        "robotoff.workers.tasks.import_image.parse_ingredients",
+        side_effect=RuntimeError("Failed to parse ingredients"),
+    )
+    ingredient_list_mocker.predict_from_ocr.return_value = IngredientPredictionOutput(
+        entities=entities, text=full_text
+    )
+    ingredient_list_mocker.MODEL_NAME = "ingredient_detection"
+    ingredient_list_mocker.MODEL_VERSION = "ingredient-detection-1.1"
+
+    import_insights = mocker.patch(
+        "robotoff.workers.tasks.import_image.import_insights"
+    )
+    barcode = "1234567890123"
+    ocr_url = "https://images.openfoodfacts.org/images/products/123/456/789/0123/1.json"
+
+    with peewee_db:
+        image = ImageModelFactory(
+            barcode=barcode,
+            server_type=ServerType.off,
+            image_id="1",
+            width=400,
+            height=400,
+        )
+        extract_ingredients_job(
+            ProductIdentifier(barcode, ServerType.off), ocr_url=ocr_url
+        )
+        ingredient_list_mocker.predict_from_ocr.assert_called_once_with(
+            ocr_url, triton_uri=None
+        )
+        parse_ingredients_mocker.assert_called_once_with("water, salt, sugar.", "en")
+        image_prediction = ImagePrediction.get_or_none(
+            ImagePrediction.model_name == "ingredient_detection",
+            ImagePrediction.image_id == image.id,
+        )
+        assert image_prediction is not None
+        entity = {
+            "end": 51,
+            "lang": {"lang": "en", "confidence": 0.9},
+            "text": "water, salt, sugar.",
+            "score": 0.9,
+            "start": 19,
+            "raw_end": 51,
+            "bounding_box": [0.0, 0.0, 0.25, 0.25],
+        }
+        assert image_prediction.data == {
+            "entities": [entity],
+        }
+        assert image_prediction.max_confidence == 0.9
+        assert image_prediction.type == "ner"
+        assert image_prediction.model_name == "ingredient_detection"
+        assert image_prediction.model_version == "ingredient-detection-1.1"
+
+        assert import_insights.call_count == 1
+        assert len(import_insights.call_args.args) == 1
+        predictions = import_insights.call_args.args[0]
+        assert len(predictions) == 0
+        assert import_insights.call_args.kwargs == {
+            "server_type": ServerType.off,
+        }


### PR DESCRIPTION
If Product Opener ingredient parser was failing, an exception was raised during insight import, due to missing fields in insight.data.

Furthermore, the coordinates in `data.bounding_box` were not normalized in case of API error.

Solves #1600