### PR TITLE
fix: Fix warning message for non-matching category in taxonomy

### DIFF
--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -762,11 +762,12 @@ class CategoryImporter(InsightImporter):
                 )
                 continue
             else:
+                original_value_tag = prediction.value_tag
                 prediction.value_tag = match_taxonomized_value(
                     prediction.value_tag, TaxonomyType.category.name
                 )
                 if prediction.value_tag is None:
-                    logger.warning(f"Could not match {prediction.value_tag} (category)")
+                    logger.warning(f"Could not match {original_value_tag} (category)")
                     continue
                 elif not cls.is_prediction_valid(product, prediction.value_tag):
                     continue


### PR DESCRIPTION
Probably adding a check for `prediction.value_tag` to log the original unmatched value instead of "None" should fix #1594

Test case:

![image](https://github.com/user-attachments/assets/dfaa2484-31d6-4221-81be-1831196ebf10)
