### PR TITLE
feat: improve extra data processing in Annotator

### DIFF
--- a/robotoff/types.py
+++ b/robotoff/types.py
@@ -5,7 +5,7 @@ import uuid
 from collections import Counter
 from typing import Any, Literal, Optional, Self
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 #: A precise expectation of what mappings looks like in json.
 #: (dict where keys are always of type `str`).
@@ -440,7 +440,8 @@ class ImportImageFlag(str, enum.Enum):
     run_nutrition_table_object_detection = "run_nutrition_table_object_detection"
 
 
-class IngredientDetectionAnnotateBody(BaseModel):
+class IngredientAnnotateBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     annotation: str
     rotation: int | None = None
     bounding_box: list[float] | None = None
@@ -465,3 +466,8 @@ class IngredientDetectionAnnotateBody(BaseModel):
                 )
 
         return self
+
+
+class CategoryAnnotateBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    value_tag: str

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from robotoff.types import IngredientDetectionAnnotateBody, NutrientData
+from robotoff.types import IngredientAnnotateBody, NutrientData
 
 
 class TestNutrientData:
@@ -64,9 +64,9 @@ class TestNutrientData:
         NutrientData.model_validate(nutrient_data)
 
 
-class TestIngredientDetectionAnnotateBody:
+class TestIngredientAnnotateBody:
     def test_ingredient_detection_annotate_body_valid(self):
-        body = IngredientDetectionAnnotateBody(
+        body = IngredientAnnotateBody(
             annotation="ingredient",
             rotation=180,
             bounding_box=[0.1, 0.2, 0.5, 0.6],
@@ -77,21 +77,21 @@ class TestIngredientDetectionAnnotateBody:
 
     def test_ingredient_detection_annotate_body_invalid_length(self):
         with pytest.raises(ValueError):
-            IngredientDetectionAnnotateBody(
+            IngredientAnnotateBody(
                 annotation="ingredient",
                 bounding_box=[0.1, 0.2, 0.5],
             )
 
     def test_ingredient_detection_annotate_body_invalid_coords(self):
         with pytest.raises(ValueError):
-            IngredientDetectionAnnotateBody(
+            IngredientAnnotateBody(
                 annotation="ingredient",
                 bounding_box=[0.1, 0.2, 1.5, 0.6],
             )
 
     def test_ingredient_detection_annotate_body_invalid_order(self):
         with pytest.raises(ValueError):
-            IngredientDetectionAnnotateBody(
+            IngredientAnnotateBody(
                 annotation="ingredient",
                 bounding_box=[0.5, 0.2, 0.1, 0.6],
             )


### PR DESCRIPTION
- validate data before processing the annotation: we don't update any more the insight (and mark it as annotated) if the data is not valid
- check that annotation == 2 if and only if data is provided