### PR TITLE
chore: fix docker-livecheck.sh

### DIFF
--- a/docker/docker-livecheck.sh
+++ b/docker/docker-livecheck.sh
@@ -2,7 +2,7 @@
 
 ENV_FILE="${ENV_FILE:-.env}"
 RET_CODE=0
-for service in `docker compose --env-file=${ENV_FILE} config  --service | tr '\n' ' '`; do 
+for service in `docker compose --env-file=${ENV_FILE} config  --services | tr '\n' ' '`; do 
     found=$(docker compose --env-file=${ENV_FILE} ps -- ${service}|grep  ${service}|grep '\bUp\b')
     if [ -z "$found" ] 
     then


### PR DESCRIPTION
with the new docker compose syntax, --services does not exist anymore and has been replaced by --services