### PR TITLE
fix: Add retry logic for redis

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -95,6 +95,18 @@ tests = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothe
 tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\""]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+description = "Function decoration for backoff and retry"
+optional = false
+python-versions = ">=3.7,<4.0"
+groups = ["main"]
+files = [
+    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
+    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
+]
+
+[[package]]
 name = "black"
 version = "25.1.0"
 description = "The uncompromising code formatter."
@@ -4674,4 +4686,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "00bc0da3a40f6e393a2535dd23061e4ce482d7f9ee3c953eb425dfc4ac0f0a71"
+content-hash = "d96d24ba7caf0c46ccb97ad05bf8aa8d3ed49e0abbee4d8b38cc2d92be2f7da6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ google-cloud-storage = "~2.14.0"
 pandas = "~2.2.2"
 pyarrow = "~17.0.0"
 rich = "~13.9.2"  # Used for CLI pretty print
+backoff = "^2.2.1"
 
 [tool.poetry.dependencies.sentry-sdk]
 version = ">=1.14,<2.9"

--- a/robotoff/workers/update_listener.py
+++ b/robotoff/workers/update_listener.py
@@ -1,8 +1,11 @@
+import time
+
 from openfoodfacts import Environment, Flavor
 from openfoodfacts.images import generate_image_url, generate_json_ocr_url
 from openfoodfacts.redis import RedisUpdate
 from openfoodfacts.redis import UpdateListener as BaseUpdateListener
 from redis import Redis
+from redis.exceptions import ConnectionError
 
 from robotoff import settings
 from robotoff.types import ProductIdentifier, ServerType
@@ -108,10 +111,49 @@ def run_update_listener():
     This daemon listens to the Redis stream containing information about
     product updates and triggers appropriate actions.
     """
-    redis_client = get_redis_client()
-    update_listener = UpdateListener(
-        redis_client=redis_client,
-        redis_stream_name=settings.REDIS_STREAM_NAME,
-        redis_latest_id_key=settings.REDIS_LATEST_ID_KEY,
-    )
-    update_listener.run()
+    max_retries = 10
+    initial_delay = 1  # seconds
+    max_delay = 300  # 5 minutes max delay
+
+    retry_count = 0
+
+    while True:
+        try:
+            logger.info("Starting Redis update listener...")
+            redis_client = get_redis_client()
+            update_listener = UpdateListener(
+                redis_client=redis_client,
+                redis_stream_name=settings.REDIS_STREAM_NAME,
+                redis_latest_id_key=settings.REDIS_LATEST_ID_KEY,
+            )
+            retry_count = 0
+            update_listener.run()
+
+        except ConnectionError as e:
+            retry_count += 1
+            delay = min(initial_delay * (2 ** (retry_count - 1)), max_delay)
+
+            logger.error(
+                "Redis connection error (attempt %d/%d): %s. Retrying in %d seconds...",
+                retry_count,
+                max_retries if max_retries > 0 else "∞",
+                str(e),
+                delay,
+            )
+
+            if max_retries > 0 and retry_count >= max_retries:
+                logger.critical(
+                    "Max retries (%d) reached. Update listener is terminating.",
+                    max_retries,
+                )
+                raise
+
+            time.sleep(delay)
+
+        except Exception as e:
+            logger.critical(
+                "Unexpected error in update listener: %s", str(e), exc_info=True
+            )
+            # for non-connection errors, wait a bit before retrying
+            time.sleep(5)
+            raise

--- a/robotoff/workers/update_listener.py
+++ b/robotoff/workers/update_listener.py
@@ -125,17 +125,17 @@ def run_update_listener():
     This daemon listens to the Redis stream containing information about
     product updates and triggers appropriate actions.
     """
-    try:
-        logger.info("Starting Redis update listener...")
-        redis_client = get_redis_client()
-        update_listener = UpdateListener(
-            redis_client=redis_client,
-            redis_stream_name=settings.REDIS_STREAM_NAME,
-            redis_latest_id_key=settings.REDIS_LATEST_ID_KEY,
-        )
-        update_listener.run()
-    except Exception as e:
-        logger.critical(
-            "Unexpected error in update listener: %s", str(e), exc_info=True
-        )
-        raise
+    logger.info("Starting Redis update listener...")
+    while True:
+        try:
+            redis_client = get_redis_client()
+            update_listener = UpdateListener(
+                redis_client=redis_client,
+                redis_stream_name=settings.REDIS_STREAM_NAME,
+                redis_latest_id_key=settings.REDIS_LATEST_ID_KEY,
+            )
+            update_listener.run()
+        except Exception as e:
+            logger.critical(
+                "Unexpected error in update listener: %s", str(e), exc_info=True
+            )

--- a/robotoff/workers/update_listener.py
+++ b/robotoff/workers/update_listener.py
@@ -110,9 +110,8 @@ class UpdateListener(BaseUpdateListener):
     max_value=60,  # we wait at most 60 seconds between retries
     jitter=backoff.random_jitter,
     on_backoff=lambda details: logger.error(
-        "Redis connection error (attempt %d/%d): %s. Retrying in %.1f seconds...",
+        "Redis connection error (attempt %d): %s. Retrying in %.1f seconds...",
         details["tries"],
-        10,
         details["exception"],
         details["wait"],
     ),

--- a/robotoff/workers/update_listener.py
+++ b/robotoff/workers/update_listener.py
@@ -1,5 +1,3 @@
-import time
-
 import backoff
 from openfoodfacts import Environment, Flavor
 from openfoodfacts.images import generate_image_url, generate_json_ocr_url

--- a/robotoff/workers/update_listener.py
+++ b/robotoff/workers/update_listener.py
@@ -107,8 +107,7 @@ class UpdateListener(BaseUpdateListener):
 @backoff.on_exception(
     backoff.expo,
     ConnectionError,
-    max_tries=10,
-    max_time=300,  # 5 minutes
+    max_value=60,  # we wait at most 60 seconds between retries
     jitter=backoff.random_jitter,
     on_backoff=lambda details: logger.error(
         "Redis connection error (attempt %d/%d): %s. Retrying in %.1f seconds...",

--- a/robotoff/workers/update_listener.py
+++ b/robotoff/workers/update_listener.py
@@ -113,7 +113,7 @@ def run_update_listener():
     """
     max_retries = 10
     initial_delay = 1  # seconds
-    max_delay = 300  # 5 minutes max delay
+    max_delay = 300  # 5 minutes
 
     retry_count = 0
 

--- a/robotoff/workers/update_listener.py
+++ b/robotoff/workers/update_listener.py
@@ -129,20 +129,17 @@ def run_update_listener():
     This daemon listens to the Redis stream containing information about
     product updates and triggers appropriate actions.
     """
-    while True:
-        try:
-            logger.info("Starting Redis update listener...")
-            redis_client = get_redis_client()
-            update_listener = UpdateListener(
-                redis_client=redis_client,
-                redis_stream_name=settings.REDIS_STREAM_NAME,
-                redis_latest_id_key=settings.REDIS_LATEST_ID_KEY,
-            )
-            update_listener.run()
-        except Exception as e:
-            logger.critical(
-                "Unexpected error in update listener: %s", str(e), exc_info=True
-            )
-            # for non-connection errors, wait a bit before retrying
-            time.sleep(5)
-            raise
+    try:
+        logger.info("Starting Redis update listener...")
+        redis_client = get_redis_client()
+        update_listener = UpdateListener(
+            redis_client=redis_client,
+            redis_stream_name=settings.REDIS_STREAM_NAME,
+            redis_latest_id_key=settings.REDIS_LATEST_ID_KEY,
+        )
+        update_listener.run()
+    except Exception as e:
+        logger.critical(
+            "Unexpected error in update listener: %s", str(e), exc_info=True
+        )
+        raise ()

--- a/robotoff/workers/update_listener.py
+++ b/robotoff/workers/update_listener.py
@@ -139,3 +139,4 @@ def run_update_listener():
             logger.critical(
                 "Unexpected error in update listener: %s", str(e), exc_info=True
             )
+            raise

--- a/robotoff/workers/update_listener.py
+++ b/robotoff/workers/update_listener.py
@@ -142,4 +142,4 @@ def run_update_listener():
         logger.critical(
             "Unexpected error in update listener: %s", str(e), exc_info=True
         )
-        raise ()
+        raise


### PR DESCRIPTION
**Fixes** #1612

**Problem**
Update listener crashes when Redis connections drop, causing service termination.

**Solution**

* Added `backoff` with `@on_exception` on `run_update_listener()` for retry handling
* Configured exponential backoff: 10 retries, 1-minute timeout, random jitter
