### PR TITLE
fix: increase timeouts for spellcheck jobs

### DIFF
--- a/robotoff/app/api.py
+++ b/robotoff/app/api.py
@@ -1747,7 +1747,7 @@ class BatchJobImportResource:
                 job_type=job_type,
                 batch_dir=batch_dir,
                 queue=low_queue,
-                job_kwargs={"timeout": "30m"},
+                job_kwargs={"timeout": "8h"},
             )
         logger.info("Batch import %s has been queued.", job_type)
 

--- a/robotoff/batch/configs/job_configs/spellcheck.yaml
+++ b/robotoff/batch/configs/job_configs/spellcheck.yaml
@@ -3,7 +3,7 @@ cpu_milli: 1000
 memory_mib: 32000
 boot_disk_mib: 100000
 max_retry_count: 1
-max_run_duration: "54000s" # 15 hours
+max_run_duration: "86400s" # 24 hours
 task_count: "1"
 parallelism: "1"
 machine_type: "g2-standard-8"


### PR DESCRIPTION
- for spellcheck import job, increase to 8 hours
- for prediction job on Google Batch, increase to 48h