### PR TITLE
fix: add more info in logging message when PO update failed

### DIFF
--- a/robotoff/off.py
+++ b/robotoff/off.py
@@ -527,7 +527,11 @@ def update_product(
     status = json.get("status_verbose")
 
     if status != "fields saved":
-        logger.warning("Unexpected status during product update: %s", status)
+        logger.warning(
+            "Unexpected status during product update: %s",
+            status,
+            extra={"response_json": json, "request_headers": r.request.headers},
+        )
 
 
 def update_product_v3(


### PR DESCRIPTION
To help understand #1635.