### PR TITLE
fix: replace processName by pid in log messages

### DIFF
--- a/robotoff/utils/logger.py
+++ b/robotoff/utils/logger.py
@@ -29,7 +29,7 @@ def configure_root_logger(logger, level: int = 20):
     logger.setLevel(level)
     handler = logging.StreamHandler()
     formatter = logging.Formatter(
-        "%(asctime)s :: %(processName)s :: "
+        "%(asctime)s :: pid %(process)d :: "
         "%(threadName)s :: %(levelname)s :: "
         "%(message)s"
     )


### PR DESCRIPTION
ProcessName is always MainProcess (we're not doing multi-processing in Robotoff), while pid is interesting to know which requests on the API triggered a gunicorn worker timeout.