### PR TITLE
fix: fix bug in extract_ingredients_job

### DIFF
--- a/robotoff/workers/tasks/import_image.py
+++ b/robotoff/workers/tasks/import_image.py
@@ -1126,7 +1126,7 @@ def extract_nutrition_job(
             max_confidence=max_confidence,
         )
 
-        if max_confidence is not None:
+        if "nutrients" in data and len(data["nutrients"]) > 0:
             # Only keep 'postprocessed' entities, as they are the most
             # relevant for the user
             prediction_data = {

--- a/tests/integration/workers/tasks/test_import_image.py
+++ b/tests/integration/workers/tasks/test_import_image.py
@@ -1,15 +1,31 @@
 import pytest
 
-from robotoff.models import ImagePrediction
+from robotoff.models import ImagePrediction, Prediction, ProductInsight
+from robotoff.off import generate_image_url, generate_json_ocr_url
 from robotoff.prediction.ingredient_list import (
     IngredientPredictionAggregatedEntity,
     IngredientPredictionOutput,
 )
 from robotoff.prediction.langid import LanguagePrediction
-from robotoff.types import ProductIdentifier, ServerType
-from robotoff.workers.tasks.import_image import extract_ingredients_job
+from robotoff.prediction.nutrition_extraction import (
+    NutrientPrediction,
+    NutritionEntities,
+    NutritionExtractionPrediction,
+)
+from robotoff.types import PredictionType, ProductIdentifier, ServerType
+from robotoff.workers.tasks.import_image import (
+    extract_ingredients_job,
+    extract_nutrition_job,
+)
+from robotoff.workers.tasks.import_image import (
+    nutrition_extraction as nutrition_extraction_module,
+)
 
 from ...models_utils import ImageModelFactory, ImagePredictionFactory, clean_db
+
+DEFAULT_BARCODE = "1234567890123"
+DEFAULT_IMAGE_ID = "1"
+DEFAULT_SOURCE_IMAGE = "/123/456/789/0123/1.jpg"
 
 
 @pytest.fixture(autouse=True)
@@ -338,3 +354,328 @@ def test_extract_ingredients_job_product_opener_api_failed(mocker, peewee_db):
         assert import_insights.call_args.kwargs == {
             "server_type": ServerType.off,
         }
+
+
+class TestExtractNutritionJob:
+    def generate_nutrition_extraction_prediction(self):
+        return NutritionExtractionPrediction(
+            entities=NutritionEntities(
+                raw=[
+                    {
+                        "word": "hranite ",
+                        "index": 0,
+                        "score": 0.9999675750732422,
+                        "entity": "O",
+                        "char_end": 8,
+                        "char_start": 0,
+                    }
+                ],
+                aggregated=[
+                    {
+                        "end": 15,
+                        "worlds": ["883", "kJ"],
+                        "score": 0.9993564486503601,
+                        "start": 13,
+                        "entity": "energy_kj_100g",
+                        "char_end": 98,
+                        "char_start": 92,
+                    }
+                ],
+                postprocessed=[
+                    {
+                        "end": 15,
+                        "text": "883 kJ",
+                        "unit": "kj",
+                        "score": 0.9993564486503601,
+                        "start": 13,
+                        "valid": True,
+                        "value": "883",
+                        "entity": "energy-kj_100g",
+                        "char_end": 98,
+                        "char_start": 92,
+                    }
+                ],
+            ),
+            nutrients={
+                "energy-kj_100g": NutrientPrediction(
+                    end=15,
+                    text="883 kJ",
+                    unit="kj",
+                    score=0.9993564486503601,
+                    start=13,
+                    value="883",
+                    entity="energy-kj_100g",
+                    char_end=98,
+                    char_start=92,
+                )
+            },
+        )
+
+    def test_extract_nutrition_job_image_prediction_exists(self, mocker, peewee_db):
+        get_image_from_url_mocker = mocker.patch(
+            "robotoff.workers.tasks.import_image.get_image_from_url",
+        )
+        with peewee_db:
+            image_model = ImageModelFactory(
+                barcode=DEFAULT_BARCODE, source_image=DEFAULT_SOURCE_IMAGE, image_id="1"
+            )
+            ImagePredictionFactory(
+                image=image_model,
+                model_name="nutrition_extractor",
+                model_version="nutrition_extractor-2.0",
+                data={},
+                max_confidence=0.9,
+                type="nutrition_extraction",
+            )
+        product_id = ProductIdentifier(DEFAULT_BARCODE, ServerType.off)
+        extract_nutrition_job(
+            product_id,
+            generate_image_url(product_id, DEFAULT_IMAGE_ID),
+            generate_json_ocr_url(product_id, DEFAULT_IMAGE_ID),
+        )
+        assert get_image_from_url_mocker.call_count == 0
+
+    def test_extract_nutrition_job_error_image_download(self, mocker, peewee_db):
+        get_image_from_url_mocker = mocker.patch(
+            "robotoff.workers.tasks.import_image.get_image_from_url", return_value=None
+        )
+        OCRResult = mocker.patch("robotoff.workers.tasks.import_image.OCRResult")
+        OCRResult.from_url.return_value = None
+        nutrition_extraction_mocker = mocker.patch(
+            "robotoff.workers.tasks.import_image.nutrition_extraction"
+        )
+        with peewee_db:
+            ImageModelFactory(
+                barcode=DEFAULT_BARCODE, source_image=DEFAULT_SOURCE_IMAGE, image_id="1"
+            )
+        product_id = ProductIdentifier(DEFAULT_BARCODE, ServerType.off)
+        extract_nutrition_job(
+            product_id,
+            generate_image_url(product_id, DEFAULT_IMAGE_ID),
+            generate_json_ocr_url(product_id, DEFAULT_IMAGE_ID),
+        )
+        assert get_image_from_url_mocker.call_count == 1
+        assert get_image_from_url_mocker.call_args.args[0] == generate_image_url(
+            product_id, DEFAULT_IMAGE_ID
+        )
+        assert OCRResult.from_url.call_count == 0
+        assert nutrition_extraction_mocker.predict.call_count == 0
+
+    def test_extract_nutrition_job_error_json_ocr_download(self, mocker, peewee_db):
+        get_image_from_url_mocker = mocker.patch(
+            "robotoff.workers.tasks.import_image.get_image_from_url"
+        )
+        nutrition_extraction_mocker = mocker.patch(
+            "robotoff.workers.tasks.import_image.nutrition_extraction"
+        )
+        OCRResult = mocker.patch("robotoff.workers.tasks.import_image.OCRResult")
+        OCRResult.from_url.return_value = None
+        with peewee_db:
+            ImageModelFactory(
+                barcode=DEFAULT_BARCODE, source_image=DEFAULT_SOURCE_IMAGE, image_id="1"
+            )
+        product_id = ProductIdentifier(DEFAULT_BARCODE, ServerType.off)
+        extract_nutrition_job(
+            product_id,
+            generate_image_url(product_id, DEFAULT_IMAGE_ID),
+            generate_json_ocr_url(product_id, DEFAULT_IMAGE_ID),
+        )
+        assert get_image_from_url_mocker.call_count == 1
+        assert get_image_from_url_mocker.call_args.args[0] == generate_image_url(
+            product_id, DEFAULT_IMAGE_ID
+        )
+        assert OCRResult.from_url.call_count == 1
+        assert OCRResult.from_url.call_args.args[0] == generate_json_ocr_url(
+            product_id, DEFAULT_IMAGE_ID
+        )
+        assert nutrition_extraction_mocker.predict.call_count == 0
+
+    def test_extract_nutrition_job_null_predict_output(self, mocker, peewee_db):
+        get_image_from_url_mocker = mocker.patch(
+            "robotoff.workers.tasks.import_image.get_image_from_url"
+        )
+        nutrition_extraction_predict_mocker = mocker.patch.object(
+            nutrition_extraction_module,
+            "predict",
+            return_value=None,
+        )
+        OCRResult = mocker.patch("robotoff.workers.tasks.import_image.OCRResult")
+        product_id = ProductIdentifier(DEFAULT_BARCODE, ServerType.off)
+
+        with peewee_db:
+            image_model = ImageModelFactory(
+                barcode=DEFAULT_BARCODE, source_image=DEFAULT_SOURCE_IMAGE, image_id="1"
+            )
+            extract_nutrition_job(
+                product_id,
+                generate_image_url(product_id, DEFAULT_IMAGE_ID),
+                generate_json_ocr_url(product_id, DEFAULT_IMAGE_ID),
+            )
+            assert get_image_from_url_mocker.call_count == 1
+            assert OCRResult.from_url.call_count == 1
+            assert nutrition_extraction_predict_mocker.call_count == 1
+            image_predictions = list(ImagePrediction.select())
+            # An image prediction was created
+            assert len(image_predictions) == 1
+            image_prediction = image_predictions[0]
+            assert image_prediction.image == image_model
+            assert image_prediction.type == "nutrition_extraction"
+            assert image_prediction.model_name == "nutrition_extractor"
+            assert image_prediction.model_version == "nutrition_extractor-2.0"
+            assert image_prediction.data == {"error": "missing_text"}
+            assert image_prediction.max_confidence is None
+            assert Prediction.select().count() == 0
+            assert ProductInsight.select().count() == 0
+
+    def test_extract_nutrition_job_null_predict_valid_prediction(
+        self, mocker, peewee_db
+    ):
+        get_image_from_url_mocker = mocker.patch(
+            "robotoff.workers.tasks.import_image.get_image_from_url"
+        )
+        nutrition_extraction_prediction = (
+            self.generate_nutrition_extraction_prediction()
+        )
+        nutrition_extraction_predict_mocker = mocker.patch.object(
+            nutrition_extraction_module,
+            "predict",
+            return_value=nutrition_extraction_prediction,
+        )
+        OCRResult = mocker.patch("robotoff.workers.tasks.import_image.OCRResult")
+        import_insights_mocker = mocker.patch(
+            "robotoff.workers.tasks.import_image.import_insights"
+        )
+        product_id = ProductIdentifier(DEFAULT_BARCODE, ServerType.off)
+
+        with peewee_db:
+            image_model = ImageModelFactory(
+                barcode=DEFAULT_BARCODE, source_image=DEFAULT_SOURCE_IMAGE, image_id="1"
+            )
+            extract_nutrition_job(
+                product_id,
+                generate_image_url(product_id, DEFAULT_IMAGE_ID),
+                generate_json_ocr_url(product_id, DEFAULT_IMAGE_ID),
+            )
+            assert get_image_from_url_mocker.call_count == 1
+            assert OCRResult.from_url.call_count == 1
+            assert nutrition_extraction_predict_mocker.call_count == 1
+            image_predictions = list(ImagePrediction.select())
+            # An image prediction was created
+            assert len(image_predictions) == 1
+            image_prediction = image_predictions[0]
+            assert image_prediction.image == image_model
+            assert image_prediction.type == "nutrition_extraction"
+            assert image_prediction.model_name == "nutrition_extractor"
+            assert image_prediction.model_version == "nutrition_extractor-2.0"
+            assert image_prediction.data is not None
+            assert set(image_prediction.data.keys()) == {"entities", "nutrients"}
+            assert isinstance(image_prediction.data["entities"], dict)
+            assert set(image_prediction.data["entities"].keys()) == {
+                "raw",
+                "aggregated",
+                "postprocessed",
+            }
+            assert isinstance(image_prediction.data["nutrients"], dict)
+            assert set(image_prediction.data["nutrients"].keys()) == {
+                "energy-kj_100g",
+            }
+            assert image_prediction.max_confidence == 0.99935645
+            # Prediction and insight creation occur during import_insights
+            assert Prediction.select().count() == 0
+            assert ProductInsight.select().count() == 0
+
+            assert import_insights_mocker.call_count == 1
+            args = import_insights_mocker.call_args.args
+            assert len(args) == 1
+            predictions = args[0]
+            assert len(predictions) == 1
+            prediction = predictions[0]
+            assert prediction.barcode == DEFAULT_BARCODE
+            assert prediction.type == PredictionType.nutrient_extraction
+            assert prediction.value_tag is None
+            assert prediction.value is None
+            assert prediction.automatic_processing is False
+            assert prediction.predictor == "nutrition_extractor"
+            assert prediction.predictor_version == "nutrition_extractor-2.0"
+            assert prediction.confidence is None
+            assert prediction.source_image == DEFAULT_SOURCE_IMAGE
+            assert prediction.server_type == ServerType.off
+            assert prediction.data == {
+                "entities": {
+                    "postprocessed": [
+                        {
+                            "end": 15,
+                            "text": "883 kJ",
+                            "unit": "kj",
+                            "score": 0.9993564486503601,
+                            "start": 13,
+                            "valid": True,
+                            "value": "883",
+                            "entity": "energy-kj_100g",
+                            "char_end": 98,
+                            "char_start": 92,
+                        }
+                    ],
+                },
+                "nutrients": {
+                    "energy-kj_100g": {
+                        "end": 15,
+                        "text": "883 kJ",
+                        "unit": "kj",
+                        "score": 0.9993564486503601,
+                        "start": 13,
+                        "value": "883",
+                        "entity": "energy-kj_100g",
+                        "char_end": 98,
+                        "char_start": 92,
+                    }
+                },
+            }
+
+    def test_extract_nutrition_job_no_valid_nutrient_extracted(self, mocker, peewee_db):
+        mocker.patch("robotoff.workers.tasks.import_image.get_image_from_url")
+        nutrition_extraction_prediction = (
+            self.generate_nutrition_extraction_prediction()
+        )
+        nutrition_extraction_prediction.nutrients = {}
+        nutrition_extraction_predict_mocker = mocker.patch.object(
+            nutrition_extraction_module,
+            "predict",
+            return_value=nutrition_extraction_prediction,
+        )
+        mocker.patch("robotoff.workers.tasks.import_image.OCRResult")
+        import_insights_mocker = mocker.patch(
+            "robotoff.workers.tasks.import_image.import_insights"
+        )
+        product_id = ProductIdentifier(DEFAULT_BARCODE, ServerType.off)
+
+        with peewee_db:
+            image_model = ImageModelFactory(
+                barcode=DEFAULT_BARCODE, source_image=DEFAULT_SOURCE_IMAGE, image_id="1"
+            )
+            extract_nutrition_job(
+                product_id,
+                generate_image_url(product_id, DEFAULT_IMAGE_ID),
+                generate_json_ocr_url(product_id, DEFAULT_IMAGE_ID),
+            )
+            assert nutrition_extraction_predict_mocker.call_count == 1
+            image_predictions = list(ImagePrediction.select())
+            # An image prediction was created
+            assert len(image_predictions) == 1
+            image_prediction = image_predictions[0]
+            assert image_prediction.image == image_model
+            assert image_prediction.type == "nutrition_extraction"
+            assert image_prediction.data is not None
+            assert set(image_prediction.data.keys()) == {"entities", "nutrients"}
+            assert isinstance(image_prediction.data["entities"], dict)
+            assert set(image_prediction.data["entities"].keys()) == {
+                "raw",
+                "aggregated",
+                "postprocessed",
+            }
+            assert isinstance(image_prediction.data["nutrients"], dict)
+            assert image_prediction.data["nutrients"] == {}
+            assert image_prediction.max_confidence == 0.99935645
+            assert Prediction.select().count() == 0
+            assert ProductInsight.select().count() == 0
+            assert import_insights_mocker.call_count == 0


### PR DESCRIPTION
A prediction was created even if all extracted entities were invalid.
I also fully tested the function using integration tests.

Fixes #1648 