### PR TITLE
fix: launch refresh insight at 7PM instead of 4PM

### DIFF
--- a/robotoff/scheduler/__init__.py
+++ b/robotoff/scheduler/__init__.py
@@ -349,7 +349,7 @@ def run():
         refresh_insights,
         "cron",
         day="*",
-        hour="16",
+        hour="19",
         max_instances=1,
     )
 


### PR DESCRIPTION
The dataset was not ready yet at 4PM, resulting in insights not being refreshed.