### PR TITLE
fix: remove store Alteza

### DIFF
--- a/data/ocr/store_regex.txt
+++ b/data/ocr/store_regex.txt
@@ -17,7 +17,6 @@ Aldi||Barissimo
 Aldi||Millville
 Alimerka
 Alnatura
-Alteza
 Amazon Fresh
 Auchan
 Asda


### PR DESCRIPTION
This store does not exist, it's only a brand

Spotted by October Food Facts :

```
I sort of forgot or overlooked another one. The store Alteza is automatically added to Alteza-brand products, however, it doesn't exist. At least, I can't find such store anywhere. It has 1825 entries on the site, less than the previous 7000 Hacendado, but it's also Spanish. There's some information about this brand and its company (EMD AG), it's just not a store, being only a brand.
```