### PR TITLE
chore: remove legacy labels.txt files

### DIFF
--- a/models/triton/nutriscore/labels.txt
+++ b/models/triton/nutriscore/labels.txt
@@ -1,5 +1,0 @@
-nutriscore-a
-nutriscore-b
-nutriscore-c
-nutriscore-d
-nutriscore-e

--- a/models/triton/nutrition_table/labels.txt
+++ b/models/triton/nutrition_table/labels.txt
@@ -1,1 +1,0 @@
-nutrition-table

--- a/models/triton/universal_logo_detector/labels.txt
+++ b/models/triton/universal_logo_detector/labels.txt
@@ -1,2 +1,0 @@
-brand
-label


### PR DESCRIPTION
We now specify the labels directly in Robotoff.