### PR TITLE
refactor: allow to log processing time for all models

### DIFF
--- a/.env
+++ b/.env
@@ -105,3 +105,8 @@ ROBOTOFF_POSTGRES_SHARED_BUFFERS=1GB
 ROBOTOFF_POSTGRES_WORK_MEM=64MB
 
 CROP_ALLOWED_DOMAINS=static.openfoodfacts.org,openfoodfacts-images.s3.eu-west-3.amazonaws.com,images.openfoodfacts.org,prices.openfoodfacts.org
+
+# Logging
+
+# To enable ML metrics logging, set this to 1.
+LOG_ML_METRICS_ENABLED=0

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -175,6 +175,9 @@ jobs:
           # Secret key to secure batch job import
           echo "BATCH_JOB_KEY=${{ secrets.BATCH_JOB_KEY }}" >> .env
 
+          # Specific logging settings
+          echo "LOG_ML_METRICS_ENABLED=1" >> .env
+
     - name: Create Docker volumes
       uses: appleboy/ssh-action@master
       with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ x-robotoff-base:
 x-robotoff-base-env:
   &robotoff-base-env
   LOG_LEVEL:
+  LOG_ML_METRICS_ENABLED:
   ROBOTOFF_INSTANCE:
   ROBOTOFF_TLD:
   ROBOTOFF_SCHEME:

--- a/robotoff/app/core.py
+++ b/robotoff/app/core.py
@@ -1,5 +1,6 @@
 import datetime
 import functools
+import logging
 from enum import Enum
 from typing import Iterable, Literal, NamedTuple, Union
 
@@ -30,10 +31,9 @@ from robotoff.models import (
 from robotoff.off import OFFAuthentication
 from robotoff.taxonomy import match_taxonomized_value
 from robotoff.types import InsightAnnotation, JSONType, ServerType
-from robotoff.utils import get_logger
 from robotoff.utils.text import get_tag
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class SkipVotedType(Enum):

--- a/robotoff/app/events.py
+++ b/robotoff/app/events.py
@@ -1,11 +1,11 @@
+import logging
 from multiprocessing import Process, SimpleQueue
 
 import requests
 
 from robotoff import settings
-from robotoff.utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class EventProcessor:

--- a/robotoff/batch/__init__.py
+++ b/robotoff/batch/__init__.py
@@ -1,6 +1,7 @@
 import base64
 import datetime
 import json
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -13,12 +14,11 @@ from robotoff.insights.importer import import_insights
 from robotoff.models import db
 from robotoff.prediction.langid import predict_lang
 from robotoff.types import BatchJobType, Prediction, PredictionType, ServerType
-from robotoff.utils import get_logger
 
 from .buckets import fetch_dataframe_from_gcs, upload_file_to_gcs
 from .launch import GoogleBatchJobConfig, launch_job
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def import_batch_predictions(job_type: BatchJobType, batch_dir: str) -> None:

--- a/robotoff/batch/launch.py
+++ b/robotoff/batch/launch.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import re
 from pathlib import Path
 from typing import Dict, List
@@ -8,9 +9,8 @@ from google.cloud import batch_v1
 from pydantic import BaseModel, Field
 
 from robotoff import settings
-from robotoff.utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class GoogleBatchJobConfig(BaseModel):

--- a/robotoff/brands.py
+++ b/robotoff/brands.py
@@ -1,21 +1,15 @@
 import functools
+import logging
 import operator
 
 from robotoff import settings
 from robotoff.products import ProductDataset
 from robotoff.taxonomy import TaxonomyType, get_taxonomy
 from robotoff.types import ServerType
-from robotoff.utils import (
-    dump_json,
-    dump_text,
-    get_logger,
-    http_session,
-    load_json,
-    text_file_iter,
-)
+from robotoff.utils import dump_json, dump_text, http_session, load_json, text_file_iter
 from robotoff.utils.cache import function_cache_register
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @functools.cache

--- a/robotoff/cli/file.py
+++ b/robotoff/cli/file.py
@@ -2,14 +2,13 @@
 Helper to download weights files for different Robotoff models.
 """
 
+import logging
 import shutil
 from pathlib import Path
 
 import requests
 
-from robotoff.utils import get_logger
-
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def download_file(url: str, destination: Path, force: bool = False) -> None:

--- a/robotoff/cli/insights.py
+++ b/robotoff/cli/insights.py
@@ -1,5 +1,6 @@
 import contextlib
 import gzip
+import logging
 import sys
 from pathlib import Path
 from typing import Iterable
@@ -15,9 +16,9 @@ from robotoff.insights.extraction import DEFAULT_OCR_PREDICTION_TYPES
 from robotoff.prediction.ocr import extract_predictions
 from robotoff.prediction.ocr.core import ocr_content_iter
 from robotoff.types import Prediction, PredictionType, ProductIdentifier, ServerType
-from robotoff.utils import get_logger, jsonl_iter
+from robotoff.utils import jsonl_iter
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_from_ocr_archive(

--- a/robotoff/cli/logos.py
+++ b/robotoff/cli/logos.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import pathlib
 
 import tqdm
@@ -8,10 +9,9 @@ from robotoff.logos import filter_logos
 from robotoff.models import ImageModel, ImagePrediction, LogoAnnotation, db
 from robotoff.off import generate_image_path
 from robotoff.types import ProductIdentifier, ServerType
-from robotoff.utils import get_logger, jsonl_iter
+from robotoff.utils import jsonl_iter
 
-logger = get_logger(__name__)
-
+logger = logging.getLogger(__name__)
 
 TYPE = "object_detection"
 

--- a/robotoff/cli/ocr.py
+++ b/robotoff/cli/ocr.py
@@ -1,12 +1,13 @@
 import base64
+import logging
 from typing import List
 
 import orjson
 import requests
 
-from robotoff.utils import get_logger, http_session
+from robotoff.utils import http_session
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def run_ocr_on_image_batch(base64_images: List[str], api_key: str) -> requests.Response:

--- a/robotoff/elasticsearch.py
+++ b/robotoff/elasticsearch.py
@@ -1,10 +1,11 @@
+import logging
+
 from elasticsearch import Elasticsearch
 
 from robotoff import settings
 from robotoff.types import ElasticSearchIndex
-from robotoff.utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_es_client() -> Elasticsearch:

--- a/robotoff/health.py
+++ b/robotoff/health.py
@@ -1,3 +1,5 @@
+import logging
+
 import requests
 from healthcheck import HealthCheck
 from influxdb_client import InfluxDBClient
@@ -8,11 +10,10 @@ from redis import Redis
 
 from robotoff import settings
 from robotoff.elasticsearch import get_es_client
-from robotoff.utils import get_logger
 
 health = HealthCheck()
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def test_connect_mongodb():

--- a/robotoff/images.py
+++ b/robotoff/images.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from pathlib import Path
 
 import imagehash
@@ -17,9 +18,9 @@ from robotoff.models import (
 )
 from robotoff.off import generate_image_path, generate_image_url
 from robotoff.types import JSONType, ProductIdentifier
-from robotoff.utils import get_image_from_url, get_logger, http_session
+from robotoff.utils import get_image_from_url, http_session
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def save_image(

--- a/robotoff/insights/annotate.py
+++ b/robotoff/insights/annotate.py
@@ -3,6 +3,7 @@
 
 import abc
 import datetime
+import logging
 import typing
 from dataclasses import dataclass
 from enum import Enum
@@ -40,9 +41,8 @@ from robotoff.types import (
     JSONType,
     NutrientData,
 )
-from robotoff.utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/robotoff/insights/extraction.py
+++ b/robotoff/insights/extraction.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from typing import Iterable
 
 from openfoodfacts.ocr import OCRResult
@@ -17,9 +18,9 @@ from robotoff.types import (
     PredictionType,
     ProductIdentifier,
 )
-from robotoff.utils import get_logger, http_session
+from robotoff.utils import http_session
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 DEFAULT_OCR_PREDICTION_TYPES: list[PredictionType] = [

--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -2,6 +2,7 @@ import abc
 import datetime
 import functools
 import itertools
+import logging
 import operator
 import typing
 import uuid
@@ -46,11 +47,11 @@ from robotoff.types import (
     ProductInsightImportResult,
     ServerType,
 )
-from robotoff.utils import get_logger, text_file_iter
+from robotoff.utils import text_file_iter
 from robotoff.utils.cache import function_cache_register
 from robotoff.utils.image import convert_bounding_box_absolute_to_relative_from_images
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @functools.cache

--- a/robotoff/insights/question.py
+++ b/robotoff/insights/question.py
@@ -1,4 +1,5 @@
 import abc
+import logging
 import pathlib
 
 from robotoff import settings
@@ -7,10 +8,10 @@ from robotoff.off import generate_image_path, generate_image_url
 from robotoff.products import get_product
 from robotoff.taxonomy import Taxonomy, TaxonomyType, get_taxonomy
 from robotoff.types import InsightType, JSONType, ProductIdentifier
-from robotoff.utils import get_logger, load_json
+from robotoff.utils import load_json
 from robotoff.utils.i18n import TranslationStore
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 DISPLAY_IMAGE_SIZE = 400
 SMALL_IMAGE_SIZE = 200

--- a/robotoff/logos.py
+++ b/robotoff/logos.py
@@ -1,6 +1,7 @@
 import datetime
 import functools
 import itertools
+import logging
 import operator
 
 import elasticsearch
@@ -32,11 +33,10 @@ from robotoff.types import (
     PredictionType,
     ServerType,
 )
-from robotoff.utils import get_logger
 from robotoff.utils.cache import function_cache_register
 from robotoff.utils.text import get_tag
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 LOGO_TYPE_MAPPING: dict[str, PredictionType] = {

--- a/robotoff/metrics.py
+++ b/robotoff/metrics.py
@@ -12,9 +12,9 @@ from requests.exceptions import JSONDecodeError, SSLError, Timeout
 from robotoff import settings
 from robotoff.models import ProductInsight, with_db
 from robotoff.types import ServerType
-from robotoff.utils import get_logger, http_session
+from robotoff.utils import http_session
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 URL_PATHS: list[str] = [
     "/ingredients-analysis?json=1",

--- a/robotoff/notifier.py
+++ b/robotoff/notifier.py
@@ -1,8 +1,10 @@
+import logging
+
 from robotoff import settings
 from robotoff.types import Prediction, ProductIdentifier
-from robotoff.utils import get_logger, http_session
+from robotoff.utils import http_session
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class NotifierInterface:

--- a/robotoff/off.py
+++ b/robotoff/off.py
@@ -1,5 +1,6 @@
 """Interacting with OFF server to eg. update products or get infos"""
 
+import logging
 import re
 from pathlib import Path
 from typing import Any
@@ -17,9 +18,9 @@ from robotoff.types import (
     ProductTypeLiteral,
     ServerType,
 )
-from robotoff.utils import get_logger, http_session
+from robotoff.utils import http_session
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class OFFAuthentication:

--- a/robotoff/prediction/category/neural/category_classifier.py
+++ b/robotoff/prediction/category/neural/category_classifier.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import numpy as np
@@ -12,11 +13,10 @@ from robotoff.types import (
     PredictionType,
     ProductIdentifier,
 )
-from robotoff.utils import get_logger
 
 from . import keras_category_classifier_3_0
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def create_prediction(

--- a/robotoff/prediction/ingredient_list/__init__.py
+++ b/robotoff/prediction/ingredient_list/__init__.py
@@ -1,5 +1,7 @@
 import dataclasses
 import functools
+import logging
+import time
 from pathlib import Path
 from typing import Union
 
@@ -16,6 +18,8 @@ from robotoff.utils import http_session
 from robotoff.utils.cache import function_cache_register
 
 from .transformers_pipeline import AggregationStrategy, TokenClassificationPipeline
+
+ml_metrics_logger = logging.getLogger("robotoff.ml_metrics")
 
 # The tokenizer assets are stored in the model directory
 INGREDIENT_NER_MODEL_DIR = settings.TRITON_MODELS_DIR / "ingredient-ner/1/model.onnx"
@@ -157,6 +161,7 @@ def predict_batch(
     :param model_version: version of the model model to use, defaults to "1"
     :return: a list of IngredientPredictionOutput (one for each input text)
     """
+    start_time = time.monotonic()
     tokenizer = get_tokenizer(INGREDIENT_NER_MODEL_DIR)
     # The postprocessing pipeline required `offsets_mapping` and
     # `special_tokens_mask``
@@ -168,6 +173,13 @@ def predict_batch(
         return_offsets_mapping=True,
         return_special_tokens_mask=True,
     )
+    ml_metrics_logger.info(
+        "Tokenization time for %s: %ss",
+        MODEL_NAME,
+        time.monotonic() - start_time,
+    )
+
+    start_time = time.monotonic()
     logits = send_ner_infer_request(
         batch_encoding.input_ids,
         batch_encoding.attention_mask,
@@ -175,6 +187,13 @@ def predict_batch(
         triton_stub=triton_stub,
         model_version=model_version,
     )
+    ml_metrics_logger.info(
+        "Inference time for %s: %ss",
+        MODEL_NAME,
+        time.monotonic() - start_time,
+    )
+
+    start_time = time.monotonic()
     pipeline = TokenClassificationPipeline(tokenizer, INGREDIENT_ID2LABEL)
 
     outputs = []
@@ -239,6 +258,11 @@ def predict_batch(
                 text=sentence,
             )
         )
+    ml_metrics_logger.info(
+        "Post-processing time for %s: %ss",
+        MODEL_NAME,
+        time.monotonic() - start_time,
+    )
     return outputs
 
 
@@ -261,8 +285,20 @@ def send_ner_infer_request(
     :param model_version: version of the model model to use, defaults to "1"
     :return: the predicted logits
     """
+    start_time = time.monotonic()
     request = build_triton_request(input_ids, attention_mask, model_name, model_version)
+    ml_metrics_logger.info(
+        "Building Triton request time for %s: %ss",
+        model_name,
+        time.monotonic() - start_time,
+    )
+    start_time = time.monotonic()
     response = triton_stub.ModelInfer(request)
+    ml_metrics_logger.info(
+        "Inference time for %s: %ss",
+        model_name,
+        time.monotonic() - start_time,
+    )
     num_tokens = response.outputs[0].shape[1]
     num_labels = response.outputs[0].shape[2]
     return np.frombuffer(

--- a/robotoff/prediction/nutrition_extraction.py
+++ b/robotoff/prediction/nutrition_extraction.py
@@ -1,6 +1,8 @@
 import dataclasses
 import functools
+import logging
 import re
+import time
 import typing
 from collections import Counter
 from pathlib import Path
@@ -20,9 +22,9 @@ from robotoff.triton import (
 )
 from robotoff.types import JSONType
 from robotoff.utils.cache import function_cache_register
-from robotoff.utils.logger import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
+ml_metrics_logger = logging.getLogger("robotoff.ml_metrics")
 
 MODEL_NAME = "nutrition_extractor"
 MODEL_VERSION = f"{MODEL_NAME}-2.0"
@@ -82,9 +84,7 @@ def predict(
         default value from settings is used (settings.TRITON_URI_NUTRITION_EXTRACTOR).
     :return: a `NutritionExtractionPrediction` object
     """
-    triton_stub = get_triton_inference_stub(
-        triton_uri or settings.TRITON_URI_NUTRITION_EXTRACTOR
-    )
+    start_time = time.monotonic()
     id2label = get_id2label(MODEL_DIR)
     processor = get_processor(MODEL_DIR)
 
@@ -94,6 +94,14 @@ def predict(
         return None
 
     words, char_offsets, _, batch_encoding = preprocess_result
+    ml_metrics_logger.info(
+        "Preprocessing time for %s: %ss", MODEL_NAME, time.monotonic() - start_time
+    )
+
+    start_time = time.monotonic()
+    triton_stub = get_triton_inference_stub(
+        triton_uri or settings.TRITON_URI_NUTRITION_EXTRACTOR
+    )
     logits = send_infer_request(
         input_ids=batch_encoding.input_ids,
         attention_mask=batch_encoding.attention_mask,
@@ -103,7 +111,18 @@ def predict(
         triton_stub=triton_stub,
         model_version=model_version,
     )
-    return postprocess(logits[0], words, char_offsets, batch_encoding, id2label)
+    ml_metrics_logger.info(
+        "Inference time for %s: %ss",
+        MODEL_NAME,
+        time.monotonic() - start_time,
+    )
+
+    start_time = time.monotonic()
+    results = postprocess(logits[0], words, char_offsets, batch_encoding, id2label)
+    ml_metrics_logger.info(
+        "Post-processing time for %s: %ss", MODEL_NAME, time.monotonic() - start_time
+    )
+    return results
 
 
 def preprocess(

--- a/robotoff/prediction/ocr/brand.py
+++ b/robotoff/prediction/ocr/brand.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 from typing import Iterable, Union
 
 from openfoodfacts.ocr import OCRResult, get_match_bounding_box, get_text
@@ -6,13 +7,13 @@ from openfoodfacts.ocr import OCRResult, get_match_bounding_box, get_text
 from robotoff import settings
 from robotoff.brands import get_brand_blacklist, keep_brand_from_taxonomy
 from robotoff.types import JSONType, Prediction, PredictionType
-from robotoff.utils import get_logger, text_file_iter
+from robotoff.utils import text_file_iter
 from robotoff.utils.cache import function_cache_register
 from robotoff.utils.text import KeywordProcessor, get_tag
 
 from .utils import generate_keyword_processor
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 # Increase version ID when introducing breaking change: changes for which we

--- a/robotoff/prediction/ocr/category.py
+++ b/robotoff/prediction/ocr/category.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from typing import Union
 
@@ -12,9 +13,8 @@ from openfoodfacts.ocr import (
 from robotoff.off import normalize_tag
 from robotoff.taxonomy import TaxonomyType, get_taxonomy
 from robotoff.types import JSONType, Prediction, PredictionType
-from robotoff.utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 # Increase version ID when introducing breaking change: changes for which we

--- a/robotoff/prediction/ocr/core.py
+++ b/robotoff/prediction/ocr/core.py
@@ -1,10 +1,11 @@
+import logging
 import pathlib
 from typing import Callable, Iterable, TextIO, Union
 
 from openfoodfacts.ocr import OCRResult
 
 from robotoff.types import JSONType, Prediction, PredictionType, ProductIdentifier
-from robotoff.utils import get_logger, jsonl_iter, jsonl_iter_fp
+from robotoff.utils import jsonl_iter, jsonl_iter_fp
 
 from .brand import find_brands
 from .category import find_category
@@ -21,7 +22,7 @@ from .product_weight import find_product_weight
 from .store import find_stores
 from .trace import find_traces
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 PREDICTION_TYPE_TO_FUNC: dict[

--- a/robotoff/prediction/ocr/grammar.py
+++ b/robotoff/prediction/ocr/grammar.py
@@ -1,10 +1,11 @@
+import logging
 from pathlib import Path
 
 from robotoff.taxonomy import Taxonomy, TaxonomyType, get_taxonomy
-from robotoff.utils import dump_json, get_logger
+from robotoff.utils import dump_json
 from robotoff.utils.text import strip_accents_v2
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def normalize_string(text: str, lowercase: bool, strip_accent: bool) -> str:

--- a/robotoff/prediction/ocr/label.py
+++ b/robotoff/prediction/ocr/label.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import re
 from typing import Iterable, Union
 
@@ -12,13 +13,13 @@ from openfoodfacts.ocr import (
 
 from robotoff import settings
 from robotoff.types import JSONType, Prediction, PredictionType
-from robotoff.utils import get_logger, text_file_iter
+from robotoff.utils import text_file_iter
 from robotoff.utils.cache import function_cache_register
 from robotoff.utils.text import KeywordProcessor
 
 from .utils import generate_keyword_processor
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 # Increase version ID when introducing breaking change: changes for which we
 # want old predictions to be removed in DB and replaced by newer ones

--- a/robotoff/prediction/ocr/packaging.py
+++ b/robotoff/prediction/ocr/packaging.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 from typing import Union
 
 from lark import Discard, Lark, Transformer
@@ -11,11 +12,11 @@ from robotoff.prediction.ocr.grammar import (
 )
 from robotoff.taxonomy import TaxonomyType
 from robotoff.types import PackagingElementProperty, Prediction, PredictionType
-from robotoff.utils import get_logger, load_json
+from robotoff.utils import load_json
 from robotoff.utils.cache import function_cache_register
 from robotoff.utils.text import strip_consecutive_spaces
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 # Increase version ID when introducing breaking change: changes for which we
 # want old predictions to be removed in DB and replaced by newer ones

--- a/robotoff/prediction/ocr/product_weight.py
+++ b/robotoff/prediction/ocr/product_weight.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import math
 import re
 from typing import Union
@@ -13,9 +14,8 @@ from openfoodfacts.ocr import (
 )
 
 from robotoff.types import Prediction, PredictionType
-from robotoff.utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 # Increase version ID when introducing breaking change: changes for which we
 # want old predictions to be removed in DB and replaced by newer ones

--- a/robotoff/prediction/upc_image.py
+++ b/robotoff/prediction/upc_image.py
@@ -1,11 +1,10 @@
+import logging
 from enum import Enum
 
 import cv2
 import numpy as np
 
-from robotoff.utils import get_logger
-
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class UPCImageType(Enum):

--- a/robotoff/products.py
+++ b/robotoff/products.py
@@ -4,6 +4,7 @@ import enum
 import functools
 import gzip
 import json
+import logging
 import os
 import shutil
 import tempfile
@@ -18,9 +19,9 @@ from pymongo import MongoClient
 
 from robotoff import settings
 from robotoff.types import JSONType, ProductIdentifier, ServerType
-from robotoff.utils import get_logger, gzip_jsonl_iter, http_session, jsonl_iter
+from robotoff.utils import gzip_jsonl_iter, http_session, jsonl_iter
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 MONGO_SELECTION_TIMEOUT_MS = 10_0000
 

--- a/robotoff/redis.py
+++ b/robotoff/redis.py
@@ -1,14 +1,14 @@
+import logging
+
 from redis import Redis
 from redis_lock import Lock as BaseLock
 from redis_lock import NotAcquired
 
 from robotoff import settings
-from robotoff.utils import get_logger
 
 redis_conn = Redis(host=settings.REDIS_HOST)
 
-
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class LockedResourceException(Exception):

--- a/robotoff/scheduler/__init__.py
+++ b/robotoff/scheduler/__init__.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import os
 import shutil
 import uuid
@@ -31,13 +32,12 @@ from robotoff.products import (
     has_jsonl_dataset_changed,
 )
 from robotoff.types import InsightType, ServerType
-from robotoff.utils import get_logger
 
 from .latent import generate_quality_facets
 
 settings.init_sentry()
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 # Note: we do not use with_db, for atomicity is handled in annotator

--- a/robotoff/scheduler/latent.py
+++ b/robotoff/scheduler/latent.py
@@ -1,3 +1,5 @@
+import logging
+
 from pymongo.collection import Collection
 
 from robotoff.models import Prediction, with_db
@@ -8,9 +10,8 @@ from robotoff.products import (
     is_valid_image,
 )
 from robotoff.types import PredictionType, ProductIdentifier, ServerType
-from robotoff.utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 FIBER_QUALITY_FACET_NAME = "en:missing-nutrition-facts-fibers-present-on-photos"
 FIBER_NUTRITION_QUALITY_FACET_NAME = (

--- a/robotoff/taxonomy.py
+++ b/robotoff/taxonomy.py
@@ -1,4 +1,5 @@
 import collections
+import logging
 
 from cachetools.func import ttl_cache
 from openfoodfacts.taxonomy import (
@@ -10,10 +11,9 @@ from openfoodfacts.taxonomy import get_taxonomy as _get_taxonomy
 from openfoodfacts.types import TaxonomyType
 
 from robotoff import settings
-from robotoff.utils import get_logger
 from robotoff.utils.cache import function_cache_register
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def generate_category_hierarchy(

--- a/robotoff/utils/__init__.py
+++ b/robotoff/utils/__init__.py
@@ -1,4 +1,5 @@
 import gzip
+import logging
 import pathlib
 from typing import Any, Callable, Iterable, Union
 
@@ -10,9 +11,9 @@ from robotoff import settings
 from robotoff.types import JSONType
 
 from .image import get_image_from_url  # noqa: F401
-from .logger import get_logger
+from .logger import get_logger  # noqa: F401
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def jsonl_iter(jsonl_path: Union[str, pathlib.Path]) -> Iterable[JSONType]:

--- a/robotoff/utils/download.py
+++ b/robotoff/utils/download.py
@@ -9,9 +9,7 @@ from requests.exceptions import SSLError, Timeout
 from robotoff import settings
 from robotoff.utils.cache import cache_http_request, disk_cache
 
-from .logger import get_logger
-
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class AssetLoadingException(Exception):

--- a/robotoff/utils/image.py
+++ b/robotoff/utils/image.py
@@ -1,3 +1,4 @@
+import logging
 from io import BytesIO
 from pathlib import Path
 
@@ -13,9 +14,7 @@ from robotoff.utils.download import (
     get_asset_from_url,
 )
 
-from .logger import get_logger
-
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def convert_image_to_array(image: Image.Image) -> np.ndarray:

--- a/robotoff/utils/text/__init__.py
+++ b/robotoff/utils/text/__init__.py
@@ -1,12 +1,11 @@
+import logging
 import re
 import unicodedata
-
-from robotoff.utils import get_logger
 
 from .flashtext import KeywordProcessor  # noqa: F401
 from .fold_to_ascii import fold, fold_without_insertion_deletion
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 CONSECUTIVE_SPACES_REGEX = re.compile(r" {2,}")
 

--- a/robotoff/workers/queues.py
+++ b/robotoff/workers/queues.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import random
 import struct
 import threading
@@ -11,9 +12,9 @@ from rq.job import Job
 from robotoff import settings
 from robotoff.redis import redis_conn
 from robotoff.types import ProductIdentifier
-from robotoff.utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
+
 high_queues = [
     Queue(f"robotoff-high-{i + 1}", connection=redis_conn)
     for i in range(settings.NUM_RQ_WORKERS)

--- a/robotoff/workers/tasks/__init__.py
+++ b/robotoff/workers/tasks/__init__.py
@@ -1,13 +1,14 @@
+import logging
+
 from robotoff.insights.importer import refresh_insights
 from robotoff.models import Prediction, ProductInsight, with_db
 from robotoff.products import fetch_jsonl_dataset, has_jsonl_dataset_changed
 from robotoff.types import ProductIdentifier
-from robotoff.utils import get_logger
 
 from .import_image import run_import_image_job  # noqa: F401
 from .product_updated import update_insights_job  # noqa: F401
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @with_db

--- a/robotoff/workers/tasks/common.py
+++ b/robotoff/workers/tasks/common.py
@@ -1,3 +1,5 @@
+import logging
+
 import requests
 
 from robotoff.insights.importer import import_insights
@@ -6,9 +8,8 @@ from robotoff.prediction.category.neural.category_classifier import CategoryClas
 from robotoff.products import get_product
 from robotoff.taxonomy import TaxonomyType, get_taxonomy
 from robotoff.types import JSONType, ProductIdentifier
-from robotoff.utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @with_db

--- a/robotoff/workers/tasks/import_image.py
+++ b/robotoff/workers/tasks/import_image.py
@@ -1,6 +1,7 @@
 import copy
 import dataclasses
 import datetime
+import logging
 from pathlib import Path
 
 import elasticsearch
@@ -60,7 +61,7 @@ from robotoff.types import (
     ProductIdentifier,
     ServerType,
 )
-from robotoff.utils import get_image_from_url, get_logger, http_session
+from robotoff.utils import get_image_from_url, http_session
 from robotoff.utils.image import (
     convert_bounding_box_absolute_to_relative,
     convert_image_to_array,
@@ -68,7 +69,7 @@ from robotoff.utils.image import (
 from robotoff.workers.queues import enqueue_job, get_high_queue, low_queue
 from robotoff.workers.tasks.common import add_category_insight_job
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @with_db

--- a/robotoff/workers/tasks/product_updated.py
+++ b/robotoff/workers/tasks/product_updated.py
@@ -1,3 +1,5 @@
+import logging
+
 from robotoff.elasticsearch import get_es_client
 from robotoff.images import delete_images
 from robotoff.insights.extraction import get_predictions_from_product_name
@@ -15,12 +17,11 @@ from robotoff.off import generate_image_url, generate_json_ocr_url, get_product_
 from robotoff.products import get_product
 from robotoff.redis import Lock, LockedResourceException
 from robotoff.types import JSONType, ProductIdentifier, ServerType
-from robotoff.utils import get_logger
 from robotoff.workers.queues import enqueue_job, get_high_queue
 from robotoff.workers.tasks.common import add_category_insight
 from robotoff.workers.tasks.import_image import run_import_image_job
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @with_db

--- a/robotoff/workers/update_listener.py
+++ b/robotoff/workers/update_listener.py
@@ -1,3 +1,5 @@
+import logging
+
 import backoff
 from openfoodfacts import Environment, Flavor
 from openfoodfacts.images import generate_image_url, generate_json_ocr_url
@@ -8,7 +10,6 @@ from redis.exceptions import ConnectionError
 
 from robotoff import settings
 from robotoff.types import ProductIdentifier, ServerType
-from robotoff.utils.logger import get_logger
 from robotoff.workers.queues import (
     enqueue_in_job,
     enqueue_job,
@@ -22,7 +23,7 @@ from robotoff.workers.tasks.product_updated import (
     update_insights_job,
 )
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_redis_client():


### PR DESCRIPTION
and use `logging.getLogger` everywhere instead of custom `get_logger` function.