### PR TITLE
chore: move clip config to triton-config folder

### DIFF
--- a/models/triton-config/clip/cpu.pbtxt
+++ b/models/triton-config/clip/cpu.pbtxt
@@ -1,0 +1,33 @@
+backend: "onnxruntime"
+max_batch_size: 32
+input [
+  {
+      name: "pixel_values"
+      data_type: TYPE_FP32
+      dims: [ -1, -1, -1 ]
+  },
+  {
+      name: "attention_mask"
+      data_type: TYPE_INT64
+      dims: [ -1 ]
+  },
+  {
+      name: "input_ids"
+      data_type: TYPE_INT64
+      dims: [ -1 ]
+  }
+]
+output [
+  {
+      name: "image_embeds"
+      data_type: TYPE_FP32
+      dims: [ 512 ]
+  }
+]
+
+instance_group [
+  {
+    count: 2
+    kind: KIND_CPU
+  }
+]

--- a/models/triton-config/clip/gpu.pbtxt
+++ b/models/triton-config/clip/gpu.pbtxt
@@ -24,3 +24,11 @@ output [
       dims: [ 512 ]
   }
 ]
+
+instance_group [
+  {
+    count: 1
+    kind: KIND_GPU
+    gpus: [ 0 ]
+  }
+]


### PR DESCRIPTION
Otherwise, Triton crashes if clip model is not present anymore.