### PR TITLE
fix: don't send auth cookies twice

### DIFF
--- a/robotoff/off.py
+++ b/robotoff/off.py
@@ -514,12 +514,13 @@ def update_product(
         raise ValueError(
             "a password or a session cookie is required to update a product"
         )
-    r = http_session.post(
+    r = requests.post(
         url,
         data=params,
         auth=settings._off_request_auth,
         cookies=cookies,
         timeout=timeout,
+        headers={"User-Agent": settings.ROBOTOFF_USER_AGENT},
     )
 
     r.raise_for_status()


### PR DESCRIPTION
Partially fixes #1635.

Due to the use of requests Session, we sometimes also sent the cookie of a previous request.