### PR TITLE
ci: fix permission issue on ~/.cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,9 @@ ENV POETRY_VIRTUALENVS_IN_PROJECT=false
 ARG OFF_UID=1000
 ARG OFF_GID=$OFF_UID
 RUN groupadd -g $OFF_GID off && \
-    useradd -u $OFF_UID -g off -m off
+    useradd -u $OFF_UID -g off -m off && \
+    mkdir -p /home/off/.cache && \
+    chown -R off:off /home/off/.cache
 
 COPY --chown=off:off i18n /opt/robotoff/i18n
 RUN cd /opt/robotoff/i18n && \


### PR DESCRIPTION
We must create the directory in the container before mounting so that the off user has permission to create files in ~/.cache.

Closes #1739.