### PR TITLE
fix: fix issue in _is_equal_nutrient_value

### DIFF
--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -1638,7 +1638,8 @@ class NutrientExtractionImporter(InsightImporter):
                 and math.isclose(float(current_value), 0.0)
             )
 
-        if current_value is None or current_unit is None:
+        # If current value or unit is missing (null or empty string), we stop here
+        if not current_value or not current_unit:
             return False
 
         # If one of the unit is missing, we cannot compare the values, so we

--- a/tests/unit/insights/test_importer.py
+++ b/tests/unit/insights/test_importer.py
@@ -2050,6 +2050,11 @@ class TestNutrientExtractionImporter:
             # Test with values < X g
             ("<0.5", "g", "0.5", "g", True),
             ("<0.6", "g", "0.5", "g", False),
+            # Test with empty current value or unit
+            ("100", "g", None, "g", False),
+            ("100", "g", "", "g", False),
+            ("100", "g", "100", "", False),
+            ("100", "g", "100", None, False),
         ],
     )
     def test__is_equal_nutrient_values(


### PR DESCRIPTION
`current_value` or `current_unit` can be empty strings. We only checked whether they were null.

Closes #1757.