### PR TITLE
fix: only run logo object detection job when OCR is ready

### DIFF
--- a/robotoff/workers/update_listener.py
+++ b/robotoff/workers/update_listener.py
@@ -117,6 +117,8 @@ class UpdateListener(BaseUpdateListener):
                         ImportImageFlag.extract_nutrition,
                         ImportImageFlag.predict_category,
                         ImportImageFlag.import_insights_from_image,
+                        # We extract text from logos, so it requires OCR
+                        ImportImageFlag.run_logo_object_detection,
                     ],
                 )
             elif event.is_product_type_change():
@@ -202,6 +204,8 @@ class UpdateListener(BaseUpdateListener):
                 ImportImageFlag.extract_nutrition,
                 ImportImageFlag.predict_category,
                 ImportImageFlag.import_insights_from_image,
+                # We extract text from logos, so it requires OCR
+                ImportImageFlag.run_logo_object_detection,
             ],
         )
 

--- a/tests/unit/workers/test_update_listener.py
+++ b/tests/unit/workers/test_update_listener.py
@@ -190,6 +190,7 @@ class TestUpdateListener:
             ImportImageFlag.extract_nutrition,
             ImportImageFlag.predict_category,
             ImportImageFlag.import_insights_from_image,
+            ImportImageFlag.run_logo_object_detection,
         ]
 
     def test_update_listener_image_deletion(self, mocker):
@@ -264,4 +265,5 @@ class TestUpdateListener:
             ImportImageFlag.extract_nutrition,
             ImportImageFlag.predict_category,
             ImportImageFlag.import_insights_from_image,
+            ImportImageFlag.run_logo_object_detection,
         ]


### PR DESCRIPTION
logo detection job also depends on OCR extraction (we extract the text content of the logo).