### PR TITLE
refactor: use match_taxonomized_value in category OCR and add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing to Robotoff
+
+Thank you for your interest in contributing to Robotoff!
+
+For detailed instructions on how to contribute, please visit our [Contributing Guide](https://openfoodfacts.github.io/robotoff/introduction/contributing/).
+
+You can also find more information about the project in our [documentation](https://openfoodfacts.github.io/robotoff).

--- a/robotoff/prediction/ocr/category.py
+++ b/robotoff/prediction/ocr/category.py
@@ -11,7 +11,7 @@ from openfoodfacts.ocr import (
 )
 
 from robotoff.off import normalize_tag
-from robotoff.taxonomy import TaxonomyType, get_taxonomy
+from robotoff.taxonomy import TaxonomyType, match_taxonomized_value
 from robotoff.types import JSONType, Prediction, PredictionType
 
 logger = logging.getLogger(__name__)
@@ -19,35 +19,25 @@ logger = logging.getLogger(__name__)
 
 # Increase version ID when introducing breaking change: changes for which we
 # want old predictions to be removed in DB and replaced by newer ones
-PREDICTOR_VERSION = "1"
+PREDICTOR_VERSION = "2"
 
 
 def category_taxonomisation(lang, match) -> str | None:
-    """Function to match categories detected via AOP REGEX with categories
+    \"\"\"Function to match categories detected via AOP REGEX with categories
     taxonomy database. If no match is possible, we return None.
-    """
+    \"\"\"
 
-    unchecked_category = lang + normalize_tag(match.group("category"))
+    unchecked_category = lang + normalize_tag(match.group(\"category\"))
 
-    checked_category = get_taxonomy(TaxonomyType.category.name).nodes.get(
-        unchecked_category
-    )
-
-    # TODO: We may want to create a utility function in Taxonomy  to match
-    # also with synonyms of the category existing in the taxonomy
-
-    if checked_category is not None:
-        return checked_category.id
-
-    return None
+    return match_taxonomized_value(unchecked_category, TaxonomyType.category.name)
 
 
 AOC_REGEX = {
-    "fr:": [
+    \"fr:\": [
         OCRRegex(
-            # re.compile(r"(?<=appellation\s).*(?=(\scontr[ôo]l[ée]e)|(\sprot[ée]g[ée]e))"),
+            # re.compile(r\"(?<=appellation\s).*(?=(\scontr[ôo]l[ée]e)|(\sprot[ée]g[ée]e))\"),
             re.compile(
-                r"(appellation)\s*(?P<category>.+)\s*(contr[ôo]l[ée]e|prot[ée]g[ée]e)",
+                r\"(appellation)\s*(?P<category>.+)\s*(contr[ôo]l[ée]e|prot[ée]g[ée]e)\",
                 re.I,
             ),
             field=OCRField.full_text_contiguous,
@@ -55,33 +45,33 @@ AOC_REGEX = {
         ),
         OCRRegex(
             re.compile(
-                r"(?P<category>.+)\s*(appellation d'origine contr[ôo]l[ée]e|appellation d'origine prot[ée]g[ée]e)",
+                r\"(?P<category>.+)\s*(appellation d'origine contr[ôo]l[ée]e|appellation d'origine prot[ée]g[ée]e)\",
                 re.I,
             ),
             field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
     ],
-    "es:": [
+    \"es:\": [
         OCRRegex(
-            re.compile(r"(?P<category>.+)(\s*denominacion de origen protegida)", re.I),
+            re.compile(r\"(?P<category>.+)(\s*denominacion de origen protegida)\", re.I),
             field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
         OCRRegex(
-            re.compile(r"(denominacion de origen protegida\s*)(?P<category>.+)", re.I),
+            re.compile(r\"(denominacion de origen protegida\s*)(?P<category>.+)\", re.I),
             field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
     ],
-    "en:": [
+    \"en:\": [
         OCRRegex(
-            re.compile(r"(?P<category>.+)\s*(aop|dop|pdo)", re.I),
+            re.compile(r\"(?P<category>.+)\s*(aop|dop|pdo)\", re.I),
             field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
         OCRRegex(
-            re.compile(r"(aop|dop|pdo)\s*(?P<category>.+)", re.I),
+            re.compile(r\"(aop|dop|pdo)\s*(?P<category>.+)\", re.I),
             field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
@@ -90,11 +80,11 @@ AOC_REGEX = {
 
 
 def find_category(content: Union[OCRResult, str]) -> list[Prediction]:
-    """This function returns a prediction of the product category.
+    \"\"\"This function returns a prediction of the product category.
     For now we are extracting categories via REGEX
     only thanks to an AOP syntax but we may find in the future
     other ways to get sure prediction of categories.
-    """
+    \"\"\"
 
     predictions = []
 
@@ -112,19 +102,19 @@ def find_category(content: Union[OCRResult, str]) -> list[Prediction]:
                 if category_value is None:
                     continue
 
-                data: JSONType = {"text": match.group()}
+                data: JSONType = {\"text\": match.group()}
                 if (
                     bounding_box := get_match_bounding_box(
                         content, match.start(), match.end()
                     )
                 ) is not None:
-                    data["bounding_box_absolute"] = bounding_box
+                    data[\"bounding_box_absolute\"] = bounding_box
 
                 predictions.append(
                     Prediction(
                         type=PredictionType.category,
                         value_tag=category_value,
-                        predictor="regex",
+                        predictor=\"regex\",
                         data=data,
                         automatic_processing=False,
                         predictor_version=PREDICTOR_VERSION,

--- a/robotoff/prediction/ocr/category.py
+++ b/robotoff/prediction/ocr/category.py
@@ -23,21 +23,21 @@ PREDICTOR_VERSION = "2"
 
 
 def category_taxonomisation(lang, match) -> str | None:
-    \"\"\"Function to match categories detected via AOP REGEX with categories
+    """Function to match categories detected via AOP REGEX with categories
     taxonomy database. If no match is possible, we return None.
-    \"\"\"
+    """
 
-    unchecked_category = lang + normalize_tag(match.group(\"category\"))
+    unchecked_category = lang + normalize_tag(match.group("category"))
 
     return match_taxonomized_value(unchecked_category, TaxonomyType.category.name)
 
 
 AOC_REGEX = {
-    \"fr:\": [
+    "fr:": [
         OCRRegex(
-            # re.compile(r\"(?<=appellation\s).*(?=(\scontr[ôo]l[ée]e)|(\sprot[ée]g[ée]e))\"),
+            # re.compile(r"(?<=appellation\s).*(?=(\scontr[ôo]l[ée]e)|(\sprot[ée]g[ée]e))"),
             re.compile(
-                r\"(appellation)\s*(?P<category>.+)\s*(contr[ôo]l[ée]e|prot[ée]g[ée]e)\",
+                r"(appellation)\s*(?P<category>.+)\s*(contr[ôo]l[ée]e|prot[ée]g[ée]e)",
                 re.I,
             ),
             field=OCRField.full_text_contiguous,
@@ -45,33 +45,33 @@ AOC_REGEX = {
         ),
         OCRRegex(
             re.compile(
-                r\"(?P<category>.+)\s*(appellation d'origine contr[ôo]l[ée]e|appellation d'origine prot[ée]g[ée]e)\",
+                r"(?P<category>.+)\s*(appellation d'origine contr[ôo]l[ée]e|appellation d'origine prot[ée]g[ée]e)",
                 re.I,
             ),
             field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
     ],
-    \"es:\": [
+    "es:": [
         OCRRegex(
-            re.compile(r\"(?P<category>.+)(\s*denominacion de origen protegida)\", re.I),
+            re.compile(r"(?P<category>.+)(\s*denominacion de origen protegida)", re.I),
             field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
         OCRRegex(
-            re.compile(r\"(denominacion de origen protegida\s*)(?P<category>.+)\", re.I),
+            re.compile(r"(denominacion de origen protegida\s*)(?P<category>.+)", re.I),
             field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
     ],
-    \"en:\": [
+    "en:": [
         OCRRegex(
-            re.compile(r\"(?P<category>.+)\s*(aop|dop|pdo)\", re.I),
+            re.compile(r"(?P<category>.+)\s*(aop|dop|pdo)", re.I),
             field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
         OCRRegex(
-            re.compile(r\"(aop|dop|pdo)\s*(?P<category>.+)\", re.I),
+            re.compile(r"(aop|dop|pdo)\s*(?P<category>.+)", re.I),
             field=OCRField.full_text_contiguous,
             processing_func=category_taxonomisation,
         ),
@@ -80,11 +80,11 @@ AOC_REGEX = {
 
 
 def find_category(content: Union[OCRResult, str]) -> list[Prediction]:
-    \"\"\"This function returns a prediction of the product category.
+    """This function returns a prediction of the product category.
     For now we are extracting categories via REGEX
     only thanks to an AOP syntax but we may find in the future
     other ways to get sure prediction of categories.
-    \"\"\"
+    """
 
     predictions = []
 
@@ -102,19 +102,19 @@ def find_category(content: Union[OCRResult, str]) -> list[Prediction]:
                 if category_value is None:
                     continue
 
-                data: JSONType = {\"text\": match.group()}
+                data: JSONType = {"text": match.group()}
                 if (
                     bounding_box := get_match_bounding_box(
                         content, match.start(), match.end()
                     )
                 ) is not None:
-                    data[\"bounding_box_absolute\"] = bounding_box
+                    data["bounding_box_absolute"] = bounding_box
 
                 predictions.append(
                     Prediction(
                         type=PredictionType.category,
                         value_tag=category_value,
-                        predictor=\"regex\",
+                        predictor="regex",
                         data=data,
                         automatic_processing=False,
                         predictor_version=PREDICTOR_VERSION,


### PR DESCRIPTION
## What

- Refactored `category_taxonomisation` in  `robotoff/prediction/ocr/category.py` to use the `match_taxonomized_value` utility function.  This enables category matching using synonyms from the taxonomy.
- Removed outdated TODO regarding synonym matching.
- Bumped `PREDICTOR_VERSION` to **"2"** to ensure existing predictions are updated with the new logic.
- Added a `CONTRIBUTING.md` file to the root directory to help new contributors.

---

## Screenshot: 
N/A (Backend refactoring and documentation changes)

---

## Fixes bug(s) : 
Fixes **#1833**

