### PR TITLE
fix: correct logical operator in barcode validation to ensure numeric string format

### DIFF
--- a/robotoff/workers/tasks/import_image.py
+++ b/robotoff/workers/tasks/import_image.py
@@ -134,7 +134,7 @@ def rerun_import_images(
         return query.count()
 
     for image_model_id, barcode, image_id, server_type_str in query:
-        if not isinstance(barcode, str) and not barcode.isdigit():
+        if not isinstance(barcode, str) or not barcode.isdigit():
             raise ValueError("Invalid barcode: %s" % barcode)
 
         product_id = ProductIdentifier(barcode, ServerType[server_type_str])


### PR DESCRIPTION
### What
- Fixed broken barcode validation logic in `rerun_import_images` (`robotoff/workers/tasks/import_image.py`, line 137).
- The original condition used `and` instead of `or`, causing the validation to **never trigger**:
  ```python
  # Before (broken): always short-circuits because barcode is always a str
  if not isinstance(barcode, str) and not barcode.isdigit():
  ```
  ```python
  # After (fixed): correctly rejects non-string or non-digit barcodes
  if not isinstance(barcode, str) or not barcode.isdigit():
  ```
- Since `barcode` from the DB is always a `str`, the first condition `not isinstance(barcode, str)` was always `False`, short-circuiting the entire `and` expression. Invalid barcodes (containing non-digit characters) were silently passing through.

### Screenshot
N/A — backend-only logic fix, no UI changes.

### Fixes bug(s)
- #1887 