### PR TITLE
docs: Add details to the returned fields related to images

### DIFF
--- a/docs/how-to-guides/robotoff-for-3rd-party-apps.md
+++ b/docs/how-to-guides/robotoff-for-3rd-party-apps.md
@@ -16,50 +16,51 @@ For detailed API endpoints and their specifications, refer to the official Robot
 
 ### Displaying Questions
 
-  * **Visibility for Non-Logged Users:** Questions should be visible to users even if they are not logged in.
-  * **Prompt for Non-Logged Users:** If a non-logged user attempts to answer a question, display a prompt to log in or create an account (or let them use our anonymous statistical voting system). Provide a setting to hide these prompts if they annoy the user.
-  * **Fetching Questions:** When a product is opened in your application, fetch the relevant Robotoff questions.
-      * **Example API Call:**
-        ``` 
-        https://robotoff.openfoodfacts.org/api/v1/questions/3274570800026?lang=en&count=3
-        
-        ```
-        This example fetches 3 questions for the barcode `3274570800026` in English.
-      * **Response Structure Example:**
-        ``` json
-        {
-          "questions": [
-            {
-              "barcode": "3274570800026",
-              "type": "add-binary",
-              "value": "Scallop",
-              "question": "Does the product belong to this category?",
-              "insight_id": "5cac03bc-a5a7-4ec2-a548-17fd9319fee7",
-              "insight_type": "category",
-              "source_image_url": "https://static.openfoodfacts.org/images/products/327/457/080/0026/front_en.4.400.jpg"
-            }
-          ],
-          "status": "found"
-        }
-        
-        ```
-      * The `lang` field in the request specifies the language of the returned `question` and `value`.
-  * **UI Display:** Display the `question` and possible answers in your application's user interface.
+- **Visibility for Non-Logged Users:** Questions should be visible to users even if they are not logged in.
+- **Prompt for Non-Logged Users:** If a non-logged user attempts to answer a question, display a prompt to log in or create an account (or let them use our anonymous statistical voting system). Provide a setting to hide these prompts if they annoy the user.
+- **Fetching Questions:** When a product is opened in your application, fetch the relevant Robotoff questions (see example below).
+- **UI Display:** Display the `question` and possible answers in your application's user interface.
+
+Example API call — fetches 3 questions for the barcode `3274570800026` in English:
+
+```
+https://robotoff.openfoodfacts.org/api/v1/questions/3274570800026?lang=en&count=3
+```
+
+The `lang` field in the request specifies the language of the returned `question` and `value`.
+
+Example response structure:
+
+```json
+{
+  "questions": [
+    {
+      "barcode": "3274570800026",
+      "type": "add-binary",
+      "value": "Scallop",
+      "question": "Does the product belong to this category?",
+      "insight_id": "5cac03bc-a5a7-4ec2-a548-17fd9319fee7",
+      "insight_type": "category",
+      "source_image_url": "https://static.openfoodfacts.org/images/products/327/457/080/0026/front_en.4.400.jpg"
+    }
+  ],
+  "status": "found"
+}
+```
 
 ### Sending Answers
 
-If a user answers a question, send the appropriate ping back to the Open Food Facts server.
+If a user answers a question, send the appropriate ping back to the Open Food Facts server using the annotate endpoint:
 
-  * **API for Annotating Insights:**
-    ``` 
-    https://robotoff.openfoodfacts.org/api/v1/insights/annotate?insight_id=(insight_id)&annotation=(1,0,-1)&update=1
-    
-    ```
-      * Replace `(insight_id)` with the `insight_id` received from the question payload.
-      * Replace `(1,0,-1)` with the user's annotation:
-          * `1`: Yes
-          * `0`: No
-          * `-1`: Skip/Don't know
+```text
+https://robotoff.openfoodfacts.org/api/v1/insights/annotate?insight_id=(insight_id)&annotation=(1,0,-1)&update=1
+```
+
+- Replace `(insight_id)` with the `insight_id` received from the question payload.
+- Replace `(1,0,-1)` with the user's annotation:
+  - `1`: Yes
+  - `0`: No
+  - `-1`: Skip/Don't know
 
 ## Authentication
 
@@ -69,21 +70,22 @@ To give credit to contributors for their answers, you need to authenticate your 
 
 Send the following header with your requests:
 
-``` 
+```text
 Authorization: Basic (base64Credentials)
-
 ```
 
 Where `base64Credentials` is the Base64 encoding of your `username:password`.
 
 ### Cookie-based Authentication
-Note: we have a cookie auth for tools hosted on *.openfoodfacts.org. Please reachout to the Robotoff team if needed.
+
+Note: we have a cookie auth for tools hosted on *.openfoodfacts.org. Please reach out to the Robotoff team if needed.
 
 ## Platform-Specific Implementations
-* Web component available at https://github.com/openfoodfacts/openfoodfacts-webcomponents
-* Flutter/Dart (available in our Dart package, and UI code is available in the official smooth-app repository
-* Android (old official app, Kotlin, some code might be usable)
-      * <https://github.com/openfoodfacts/openfoodfacts-androidapp/issues/3024>
-      * <https://github.com/openfoodfacts/openfoodfacts-androidapp/issues/2931>
-* iOS (old official app, Swift, some code might be usable)
-      * https://github.com/openfoodfacts/openfoodfacts-ios
+
+- Web component available at <https://github.com/openfoodfacts/openfoodfacts-webcomponents>
+- Flutter/Dart (available in our Dart package, and UI code is available in the official smooth-app repository)
+- Android (old official app, Kotlin, some code might be usable)
+  - <https://github.com/openfoodfacts/openfoodfacts-androidapp/issues/3024>
+  - <https://github.com/openfoodfacts/openfoodfacts-androidapp/issues/2931>
+- iOS (old official app, Swift, some code might be usable)
+  - <https://github.com/openfoodfacts/openfoodfacts-ios>

--- a/docs/references/api.yml
+++ b/docs/references/api.yml
@@ -907,7 +907,7 @@ paths:
                     - type
                     - value
                 server_type:
-                  $ref: "#/components/parameters/server_type"
+                  $ref: "#/components/schemas/ServerType"
               required:
               - annotations
       responses:
@@ -1818,7 +1818,7 @@ components:
           type: string
           example: "https://static.openfoodfacts.org/images/attributes/dist/nutriscore-a.svg"
         server_type:
-          $ref: "#/components/parameters/server_type"
+          $ref: "#/components/schemas/ServerType"
         source_image_url:
           description: |
             The URL of the image the insight was generated from. This is provided as additional context
@@ -1918,7 +1918,7 @@ components:
           description: The confidence score of the annotation, between 0 and 1. The larger the score is the more confident we are in the annotation.
 
         server_type:
-          $ref: "#/components/parameters/server_type"
+          $ref: "#/components/schemas/ServerType"
 
         source_image:
           type: string
@@ -2010,7 +2010,7 @@ components:
               - `flashtext` for all predictions generated using flashtext library
               - `regex` for all predictions generated using simple regex
         server_type:
-          $ref: "#/components/parameters/server_type"
+          $ref: "#/components/schemas/ServerType"
         confidence:
           type: number
           example: 0.95
@@ -2029,7 +2029,7 @@ components:
           description: the barcode of the product the image is associated with
           example: "5410041040807"
         server_type:
-          $ref: "#/components/parameters/server_type"
+          $ref: "#/components/schemas/ServerType"
         source_image: 
           type: string
           description: the path of the URL of the image
@@ -2050,6 +2050,17 @@ components:
         deleted:
           type: boolean
           description: whether the image has been deleted from our database or not
+
+    ServerType:
+      type: string
+      description: The server type (=project) to use, such as 'off' (Open Food Facts), 'obf' (Open Beauty Facts),...
+      default: "off"
+      enum:
+      - "off"
+      - "obf"
+      - "opff"
+      - "opf"
+      - "off_pro"
 
   parameters:
     image_url:
@@ -2103,14 +2114,7 @@ components:
       required: false
       description: The server type (=project) to use, such as 'off' (Open Food Facts), 'obf' (Open Beauty Facts),...
       schema:
-        type: string
-        default: "off"
-        enum:
-        - "off"
-        - "obf"
-        - "opff"
-        - "opf"
-        - "off_pro"
+        $ref: "#/components/schemas/ServerType"
     insight_types:
       name: insight_types
       in: query

--- a/docs/references/api.yml
+++ b/docs/references/api.yml
@@ -1225,16 +1225,7 @@ paths:
                     minLength: 1
                     example: "0748162621021"
                   server_type:
-                    type: string
-                    description: |
-                      The server type (=project) to use, such as 'off' (Open Food Facts), 'obf' (Open Beauty Facts),...
-                      Only 'off' is currently supported for category prediction
-                    default: "off"
-                    enum:
-                    - "off"
-                    - "obf"
-                    - "opff"
-                    - "opf"
+                    $ref: "#/components/schemas/ServerType"
                   deepest_only:
                     type: boolean
                     description: |

--- a/docs/references/api.yml
+++ b/docs/references/api.yml
@@ -1480,22 +1480,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  predictions:
-                    type: array
-                    description: a list of predicted languages, sorted by descending probability
-                    items:
-                      type: object
-                      properties:
-                        lang:
-                          type: string
-                          description: the predicted language (2-letter code)
-                          example: "en"
-                        confidence:
-                          type: number
-                          description: the probability of the predicted language
-                          example: 0.9
+                $ref: "#/components/schemas/LanguagePredictionResponse"
         "400":
           description: "An HTTP 400 is returned if the provided parameters are invalid"
     post:
@@ -1537,22 +1522,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  predictions:
-                    type: array
-                    description: a list of predicted languages, sorted by descending probability
-                    items:
-                      type: object
-                      properties:
-                        lang:
-                          type: string
-                          description: the predicted language (2-letter code)
-                          example: "en"
-                        confidence:
-                          type: number
-                          description: the probability of the predicted language
-                          example: 0.9
+                $ref: "#/components/schemas/LanguagePredictionResponse"
         "400":
           description: "An HTTP 400 is returned if the provided parameters are invalid"
 
@@ -2040,6 +2010,25 @@ components:
       - "opff"
       - "opf"
       - "off_pro"
+
+    LanguagePredictionResponse:
+      type: object
+      description: the predicted languages, sorted by descending probability
+      properties:
+        predictions:
+          type: array
+          description: a list of predicted languages, sorted by descending probability
+          items:
+            type: object
+            properties:
+              lang:
+                type: string
+                description: the predicted language (2-letter code)
+                example: "en"
+              confidence:
+                type: number
+                description: the probability of the predicted language
+                example: 0.9
 
   parameters:
     image_url:

--- a/docs/references/api.yml
+++ b/docs/references/api.yml
@@ -1762,8 +1762,7 @@ components:
         source_image:
           type: string
           description: the path of the image the insight was generated from.
-        image: 
-          description: Details about the image associated with the insight, if any.
+        image:
           $ref: "#/components/schemas/ImageDetails"
         with_image:
           type: boolean
@@ -1890,7 +1889,6 @@ components:
           type: integer
 
         image:
-          description: Details about the image associated with the logo.
           $ref: "#/components/schemas/ImageDetails"
 
         nearest_neighbors:

--- a/docs/references/api.yml
+++ b/docs/references/api.yml
@@ -1769,6 +1769,9 @@ components:
         source_image:
           type: string
           description: the path of the image the insight was generated from.
+        image: 
+          description: Details about the image associated with the insight, if any.
+          $ref: "#/components/schemas/ImageDetails"
         with_image:
           type: boolean
           description: whether the insight has an associated image or not
@@ -1845,6 +1848,9 @@ components:
             the `value` may also be used to update Product Opener.
           type: string
           example: "en:nutriscore-grade-a"
+        with_image:
+          type: boolean
+          description: whether the insight has an associated image or not
 
     LogoDetails:
       description: Logo annotation details
@@ -1892,7 +1898,7 @@ components:
 
         image:
           description: Details about the image associated with the logo.
-          type: object
+          $ref: "#/components/schemas/ImageDetails"
 
         nearest_neighbors:
           type: object
@@ -2010,6 +2016,40 @@ components:
           example: 0.95
           description: |
             confidence score of the prediction, it is only provided for ML-based predictions. It may be null.
+    ImageDetails:
+      type: object
+      description: Details about a product image
+      properties:
+        image_id:
+          type: string
+          description: the ID of the image
+          example: "3742678"
+        barcode:
+          type: string
+          description: the barcode of the product the image is associated with
+          example: "5410041040807"
+        server_type:
+          $ref: "#/components/parameters/server_type"
+        source_image: 
+          type: string
+          description: the path of the URL of the image
+          example: "/762/221/044/9283/189.jpg"
+        width:
+          type: integer
+          description: the width of the image in pixels
+          example: 400
+        height:
+          type: integer
+          description: the height of the image in pixels
+          example: 300
+        uploaded_at:
+          type: string
+          format: date-time
+          description: the datetime of the image upload
+          example: "2020-12-15T07:32:16"
+        deleted:
+          type: boolean
+          description: whether the image has been deleted from our database or not
 
   parameters:
     image_url:

--- a/docs/references/api.yml
+++ b/docs/references/api.yml
@@ -2125,7 +2125,7 @@ components:
       description: Comma separated list, filter by country value (2-letter code)
       schema:
         type: string
-      example: uk
+        example: uk
     brands:
       name: brands
       in: query
@@ -2139,7 +2139,7 @@ components:
       description: Filter by value tag, i.e the value that is going to be sent to Product Opener
       schema:
         type: string
-      example: en:organic
+        example: en:organic
     page:
       name: page
       in: query
@@ -2158,14 +2158,14 @@ components:
     campaigns:
       name: campaigns
       in: query
-      description: Filter by annotation campaigns (the insight must have all the campaigns) An annotation campaign allows to only retrieve questions or insights based on arbitrary criteria defined during insight import.
+      description: Filter by annotation campaigns (the insight must have all the campaigns). An annotation campaign allows to only retrieve questions or insights based on arbitrary criteria defined during insight import.
       schema:
         type: string
         example: agribalyse-category
     predictor:
       name: predictor
       in: query
-      description: Filter by predictor value A predictor refers to the model/method that was used to generate the prediction.
+      description: Filter by predictor value. A predictor refers to the model/method that was used to generate the prediction.
       schema:
         type: string
         example: universal-logo-detector

--- a/docs/references/api.yml
+++ b/docs/references/api.yml
@@ -416,43 +416,31 @@ paths:
       - $ref: "#/components/parameters/image_url"
       - name: y_min
         in: query
-        description: |
-          The minimum y-coordinate for cropping, relative to the image height.
-          We use relative coordinates, with (0, 0) being the upper left corner and
-          (1, 1) being the lower right corner.
+        description: The minimum y-coordinate for cropping, relative to the image height.
         example: 0.47795143723487854
         schema:
           type: number
           minimum: 0
           maximum: 1
       - name: x_min
-        description: |
-          The minimum x-coordinate for cropping, relative to the image width.
-          We use relative coordinates, with (0, 0) being the upper left corner and
-          (1, 1) being the lower right corner.
         in: query
+        description: The minimum x-coordinate for cropping, relative to the image width.
         example: 0.5583494305610657
         schema:
           type: number
           minimum: 0
           maximum: 1
       - name: y_max
-        description: |
-          The maximum y-coordinate for cropping, relative to the image height.
-          We use relative coordinates, with (0, 0) being the upper left corner and
-          (1, 1) being the lower right corner.
         in: query
+        description: The maximum y-coordinate for cropping, relative to the image height.
         example: 0.5653171539306641
         schema:
           type: number
           minimum: 0
           maximum: 1
       - name: x_max
-        description: |
-          The maximum x-coordinate for cropping, relative to the image width.
-          We use relative coordinates, with (0, 0) being the upper left corner and
-          (1, 1) being the lower right corner.
         in: query
+        description: The maximum x-coordinate for cropping, relative to the image width.
         example: 0.6795185804367065
         schema:
           type: number

--- a/docs/references/api.yml
+++ b/docs/references/api.yml
@@ -146,6 +146,7 @@ paths:
                     type: integer
                     description: The total number of questions that meet the provided criteria
                   questions:
+
                     type: array
                     description: |
                       A list of `[value_tag, count]` tuples, where `value_tag` is a string
@@ -156,6 +157,8 @@ paths:
                       maxItems: 2
                       example: ["en:organic", 42]
                       items:
+                        # This is an array of tuple. To properly document it we need OpenAPIv3.1
+                        # https://stackoverflow.com/questions/57464633/how-to-define-a-json-array-with-concrete-item-definition-for-every-index-i-e-a
                         oneOf:
                         - type: string
                           description: The `value_tag`

--- a/docs/references/api.yml
+++ b/docs/references/api.yml
@@ -1219,7 +1219,16 @@ paths:
                     minLength: 1
                     example: "0748162621021"
                   server_type:
-                    $ref: "#/components/schemas/ServerType"
+                    type: string
+                    description: |
+                      The server type (=project) to use, such as 'off' (Open Food Facts), 'obf' (Open Beauty Facts),...
+                      Only 'off' is currently supported for category prediction
+                    default: "off"
+                    enum:
+                    - "off"
+                    - "obf"
+                    - "opff"
+                    - "opf"
                   deepest_only:
                     type: boolean
                     description: |
@@ -1726,8 +1735,6 @@ components:
         source_image:
           type: string
           description: the path of the image the insight was generated from.
-        image:
-          $ref: "#/components/schemas/ImageDetails"
         with_image:
           type: boolean
           description: whether the insight has an associated image or not
@@ -1804,9 +1811,6 @@ components:
             the `value` may also be used to update Product Opener.
           type: string
           example: "en:nutriscore-grade-a"
-        with_image:
-          type: boolean
-          description: whether the insight has an associated image or not
 
     LogoDetails:
       description: Logo annotation details
@@ -1985,9 +1989,11 @@ components:
           example: "5410041040807"
         server_type:
           $ref: "#/components/schemas/ServerType"
-        source_image: 
+        source_image:
           type: string
-          description: the path of the URL of the image
+          description: |
+            The path portion of the image URL (not the full URL).
+            Prefix with `https://images.openfoodfacts.org/images/products` to obtain the absolute URL.
           example: "/762/221/044/9283/189.jpg"
         width:
           type: integer
@@ -2001,7 +2007,7 @@ components:
           type: string
           format: date-time
           description: the datetime of the image upload
-          example: "2020-12-15T07:32:16"
+          example: "2020-12-15T07:32:16+00:00"
         deleted:
           type: boolean
           description: whether the image has been deleted from our database or not

--- a/docs/references/api.yml
+++ b/docs/references/api.yml
@@ -145,8 +145,6 @@ paths:
                   count:
                     type: integer
                     description: The total number of questions that meet the provided criteria
-                  # This is an array of tuple. To properly document it we need OpenAPIv3.1
-                  # https://stackoverflow.com/questions/57464633/how-to-define-a-json-array-with-concrete-item-definition-for-every-index-i-e-a
                   questions:
                     type: array
                     items:

--- a/docs/references/api.yml
+++ b/docs/references/api.yml
@@ -145,6 +145,8 @@ paths:
                   count:
                     type: integer
                     description: The total number of questions that meet the provided criteria
+                  # This is an array of tuple. To properly document it we need OpenAPIv3.1
+                  # https://stackoverflow.com/questions/57464633/how-to-define-a-json-array-with-concrete-item-definition-for-every-index-i-e-a
                   questions:
                     type: array
                     items:

--- a/docs/references/api.yml
+++ b/docs/references/api.yml
@@ -145,16 +145,25 @@ paths:
                   count:
                     type: integer
                     description: The total number of questions that meet the provided criteria
-                  # This is an array of tuple. To properly document it we need OpenAPIv3.1
+                  # Each item is a [value_tag, count] tuple. Inner tuple shape cannot
+                  # be expressed precisely in OpenAPI 3.0 — use `prefixItems` in 3.1.
                   # https://stackoverflow.com/questions/57464633/how-to-define-a-json-array-with-concrete-item-definition-for-every-index-i-e-a
                   questions:
                     type: array
+                    description: |
+                      A list of `[value_tag, count]` tuples, where `value_tag` is a string
+                      and `count` is the number of unanswered questions for that `value_tag`.
                     items:
-                      oneOf:
-                      - type: string
-                        description: The `value_tag`
-                      - type: integer
-                        description: The number of questions for this `value_tag`
+                      type: array
+                      minItems: 2
+                      maxItems: 2
+                      example: ["en:organic", 42]
+                      items:
+                        oneOf:
+                        - type: string
+                          description: The `value_tag`
+                        - type: integer
+                          description: The number of questions for this `value_tag`
                   status:
                     type: string
                     description: The request status


### PR DESCRIPTION
The first commit is the actual data addition. The other ones are suggestion of improvements from AI review


## Stuff I've learned thanks to AI review


From the spec, `schema` is for to defined objects used in input/output. Whereas `responses` and `parameters` are more specific (only input or only output)
https://spec.openapis.org/oas/v3.2.0.html#components-object



> Any sibling elements of a $ref are ignored. This is because $ref works by replacing itself and everything on its level with the definition it is pointing at.

https://swagger.io/docs/specification/v3_0/using-ref/


 ## DOcs deployement

The docs deployement got broken because of the pygments update #1882 

Looks like it does not support anymore the codeblocks nested into lists