### PR TITLE
fix(ocr): stop eu/non-eu agriculture false positives on narrow tags

### DIFF
--- a/robotoff/prediction/ocr/label.py
+++ b/robotoff/prediction/ocr/label.py
@@ -106,16 +106,23 @@ LABELS_REGEX = {
     ],
     "en:eu-agriculture": [
         # The negative lookafter/lookbehind forbid matching "agriculture ue/non
-        # ue"
+        # ue" and the english "eu/non eu agriculture" combined form (where "eu
+        # agriculture" is preceded by "non" or a slash separator)
         OCRRegex(
-            re.compile(r"agriculture ue(?!\s?/)|(?<!-)\s?eu agriculture", re.I),
+            re.compile(
+                r"agriculture ue(?!\s?/)|(?<![-/])(?<!non)(?<!non )\seu agriculture|(?<![-/\sa-z])eu agriculture",
+                re.I,
+            ),
             field=OCRField.full_text_contiguous,
         ),
     ],
     "en:non-eu-agriculture": [
+        # The negative lookbehind forbids matching the "eu / non-eu agriculture"
+        # combined form, where "non-eu agriculture" is preceded by a slash
         OCRRegex(
             re.compile(
-                r"agriculture non\s?(?:-\s?)?ue|non\s?(?:-\s?)?eu agriculture", re.I
+                r"agriculture non\s?(?:-\s?)?ue|(?<![/-])(?<!/ )non\s?(?:-\s?)?eu agriculture",
+                re.I,
             ),
             field=OCRField.full_text_contiguous,
         ),

--- a/tests/unit/prediction/ocr/test_label.py
+++ b/tests/unit/prediction/ocr/test_label.py
@@ -32,6 +32,22 @@ def test_es_ocr_regex(input_str: str, is_match: bool, output: str | None):
         ("homologation LA 42/05", ["fr:label-rouge"]),
         ("Homologation n°LA19/05", ["fr:label-rouge"]),
         ("Homologation n°LA 02/91", ["fr:label-rouge"]),
+        # The combined "eu/non-eu agriculture" form must only yield
+        # en:eu-non-eu-agriculture, never the narrow en:eu-agriculture or
+        # en:non-eu-agriculture tags (see #1245)
+        ("agriculture ue/non ue", ["en:eu-non-eu-agriculture"]),
+        ("agriculture ue / non ue", ["en:eu-non-eu-agriculture"]),
+        ("agriculture ue/non-ue", ["en:eu-non-eu-agriculture"]),
+        ("eu/non eu agriculture", ["en:eu-non-eu-agriculture"]),
+        ("eu/non-eu agriculture", ["en:eu-non-eu-agriculture"]),
+        ("eu / non-eu agriculture", ["en:eu-non-eu-agriculture"]),
+        # Genuine narrow forms must still be detected
+        ("agriculture ue", ["en:eu-agriculture"]),
+        ("eu agriculture", ["en:eu-agriculture"]),
+        ("agriculture non ue", ["en:non-eu-agriculture"]),
+        ("agriculture non-ue", ["en:non-eu-agriculture"]),
+        ("non eu agriculture", ["en:non-eu-agriculture"]),
+        ("non-eu agriculture", ["en:non-eu-agriculture"]),
     ],
 )
 def test_find_labels(text: str, value_tags: list[str]):


### PR DESCRIPTION
## summary

stops the narrow `en:eu-agriculture` and `en:non-eu-agriculture` regexes from firing on the combined "eu/non-eu agriculture" label, which is the false positive described in the issue. only `en:eu-non-eu-agriculture` should match that text.

## motivation

Closes #1245

the combined label is detected fine, but on the english word order the narrow tags also matched. their lookbehinds only rejected a leading hyphen, so text like `eu/non eu agriculture` or `eu / non-eu agriculture` matched the trailing "eu agriculture" / "non-eu agriculture" and produced extra insights that are hard to validate. the issue notes only `en:eu-non-eu-agriculture` is trustworthy.

## changes

- `en:eu-agriculture`: tighten the english branch so " eu agriculture" is rejected when preceded by "non" or a slash separator, and bare "eu agriculture" only matches at a real boundary (not after a letter/slash/hyphen). the french `agriculture ue(?!\s?/)` branch is unchanged.
- `en:non-eu-agriculture`: add a lookbehind so "non-eu agriculture" is rejected when preceded by a slash (the `eu / non-eu agriculture` combined form). the french `agriculture non ...ue` branch is unchanged.
- left the temporary guard in `robotoff/insights/importer.py` in place on purpose. that re-enables insight generation and felt like a separate decision once you've had a look at the regex coverage. happy to do it as a follow-up.

## testing

added parametrized cases to `tests/unit/prediction/ocr/test_label.py::test_find_labels` covering both the false-positive forms and the genuine standalone forms:

```
agriculture ue/non ue        -> en:eu-non-eu-agriculture
agriculture ue / non ue      -> en:eu-non-eu-agriculture
agriculture ue/non-ue        -> en:eu-non-eu-agriculture
eu/non eu agriculture        -> en:eu-non-eu-agriculture
eu/non-eu agriculture        -> en:eu-non-eu-agriculture
eu / non-eu agriculture      -> en:eu-non-eu-agriculture
agriculture ue               -> en:eu-agriculture
eu agriculture               -> en:eu-agriculture
agriculture non ue           -> en:non-eu-agriculture
agriculture non-ue           -> en:non-eu-agriculture
non eu agriculture           -> en:non-eu-agriculture
non-eu agriculture           -> en:non-eu-agriculture
```

`uv run pytest tests/unit/prediction/ocr/test_label.py` ... 21 passed. black, isort, flake8 and mypy are clean on both changed files.

## notes for reviewers

- the regex is the load-bearing part. the lookbehinds in python re have to be fixed-width, so the "preceded by non" guard is split into `(?<!non)(?<!non )` rather than one variable-width assertion. worth a close read there.
- if you have a sample of real rejected `en:eu-agriculture` / `en:non-eu-agriculture` insights, i'm glad to add their OCR text as extra cases so the coverage is anchored on real noise rather than the synthetic forms above.
