### PR TITLE
fix: replace obsolete facet URLs with /facets/ prefix

### DIFF
--- a/robotoff/brands.py
+++ b/robotoff/brands.py
@@ -101,7 +101,7 @@ def generate_brand_list(
 ) -> list[tuple[str, str]]:
     min_length = min_length or 0
     brand_taxonomy = get_taxonomy(TaxonomyType.brand.name)
-    url = settings.BaseURLProvider.world(server_type) + "/brands.json"
+    url = settings.BaseURLProvider.world(server_type) + "/facets/brands.json"
     brand_count_list = http_session.get(url).json()["tags"]
 
     brand_count = {tag["id"]: tag for tag in brand_count_list}

--- a/robotoff/metrics.py
+++ b/robotoff/metrics.py
@@ -16,11 +16,11 @@ from robotoff.utils import http_session
 logger = logging.getLogger(__name__)
 
 URL_PATHS: list[str] = [
-    "/ingredients-analysis?json=1",
-    "/data-quality?json=1",
-    "/ingredients?stats=1&json=1",
-    "/states?json=1",
-    "/misc?json=1",
+    "/facets/ingredients-analysis?json=1",
+    "/facets/data-quality?json=1",
+    "/facets/ingredients?stats=1&json=1",
+    "/facets/states?json=1",
+    "/facets/misc?json=1",
 ]
 
 COUNTRY_TAGS = [
@@ -136,7 +136,7 @@ def save_facet_metrics():
             inserts += generate_metrics_from_path(
                 server_type,
                 country_tag,
-                "/entry-date/{}/contributors?json=1".format(
+                "/facets/entry-date/{}/contributors?json=1".format(
                     # get contribution metrics for the previous day
                     (target_datetime - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
                 ),
@@ -148,7 +148,7 @@ def save_facet_metrics():
 
     try:
         inserts += generate_metrics_from_path(
-            server_type, "world", "/countries?json=1", target_datetime
+            server_type, "world", "/facets/countries?json=1", target_datetime
         )
     except Exception:
         logger.exception()
@@ -159,7 +159,10 @@ def save_facet_metrics():
 
 
 def get_facet_name(url: str) -> str:
-    return urlparse(url)[2].strip("/").replace("-", "_")
+    path = urlparse(url)[2].strip("/")
+    # facet pages now live under a common "/facets/" prefix (ex:
+    # "/facets/states"), so only the last path segment is the facet name
+    return path.rsplit("/", 1)[-1].replace("-", "_")
 
 
 def generate_metrics_from_path(

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,19 @@
+import pytest
+
+from robotoff.metrics import get_facet_name
+
+
+@pytest.mark.parametrize(
+    "url,expected_facet_name",
+    [
+        ("https://world.openfoodfacts.org/facets/states?json=1", "states"),
+        ("https://world.openfoodfacts.org/facets/data-quality?json=1", "data_quality"),
+        (
+            "https://world.openfoodfacts.org/facets/entry-date/2024-01-01/contributors?json=1",
+            "contributors",
+        ),
+        ("https://world.openfoodfacts.org/facets/brands.json", "brands.json"),
+    ],
+)
+def test_get_facet_name(url: str, expected_facet_name: str):
+    assert get_facet_name(url) == expected_facet_name


### PR DESCRIPTION
Product Opener moved facet pages under a `/facets/` prefix a while back (`/states` -> `/facets/states`, `/brands.json` -> `/facets/brands.json`, etc). Robotoff was still hitting the old paths in two places:

- `robotoff/metrics.py`: the `URL_PATHS` list used for `save_facet_metrics()`, plus the inline `/entry-date/{date}/contributors` and `/countries` calls in the same function.
- `robotoff/brands.py`: `generate_brand_list()` was fetching `/brands.json` instead of `/facets/brands.json`.

Both are used for nightly-ish jobs (influxdb facet metrics and the brand list used for OCR taxonomy matching), so they'd have been quietly failing/returning nothing once Product Opener fully retires the old URLs.

One thing that needed care: `get_facet_name()` derives the `facet` tag written to influxdb by stripping the whole URL path (e.g. `/states` -> `states`). With the `/facets/` prefix added, that same logic would have turned every tag into `facets_states`, `facets_data_quality`, etc, silently breaking existing dashboards/queries built on the old tag names. I changed it to take just the last path segment instead, so the tag names are unaffected.

Added `tests/unit/test_metrics.py` covering `get_facet_name()` for a plain facet, a hyphenated one, the `entry-date/.../contributors` case, and the `.json` brands case.

Verified: `ruff check` / `ruff format --check` pass on the touched files, and `pytest tests/unit/test_metrics.py tests/unit/test_brands.py` passes (11/11) on Python 3.12. I didn't have a full docker/postgres/elasticsearch dev environment available, so I couldn't run the whole `make tests` suite, but nothing else in the repo imports `get_facet_name`, `URL_PATHS`, or the changed `brands.py` line, so this should be a self-contained change.

Closes #1548
