### PR TITLE
fix(ocr): use a date-relative window for expiration dates

### DIFF
--- a/robotoff/prediction/ocr/expiration_date.py
+++ b/robotoff/prediction/ocr/expiration_date.py
@@ -16,6 +16,39 @@ from robotoff.types import JSONType, Prediction, PredictionType
 # want old predictions to be removed in DB and replaced by newer ones
 PREDICTOR_VERSION = "1"
 
+# A detected date is only kept as an expiration date if its year falls within a
+# plausible window around the current date. Best-before / expiration dates are
+# usually in the future, but can be slightly in the past for products still on
+# shelves, so we allow a small margin on both sides. Dates far outside this
+# window are almost always OCR noise or an unrelated date (e.g. a manufacturing
+# lot number misread as a date).
+#
+# The window is computed relative to the current date (see
+# `is_plausible_expiration_date`) rather than hardcoded, so it never becomes
+# stale: a previous hardcoded upper bound silently dropped every date from the
+# then-future once that year arrived.
+MAX_YEARS_IN_PAST = 5
+MAX_YEARS_IN_FUTURE = 15
+
+
+def is_plausible_expiration_date(
+    date: datetime.date, today: datetime.date | None = None
+) -> bool:
+    """Return True if `date` is a plausible expiration date, i.e. its year is
+    within `MAX_YEARS_IN_PAST` years before and `MAX_YEARS_IN_FUTURE` years
+    after the current year.
+
+    :param date: the candidate expiration date
+    :param today: the reference date, defaults to `datetime.date.today()`
+        (mainly useful for testing)
+    """
+    if today is None:
+        today = datetime.date.today()
+
+    return (
+        today.year - MAX_YEARS_IN_PAST <= date.year <= today.year + MAX_YEARS_IN_FUTURE
+    )
+
 
 def process_full_digits_expiration_date(match, short: bool) -> datetime.date | None:
     day, month, year = match.group(1, 2, 3)
@@ -73,7 +106,7 @@ def find_expiration_date(content: OCRResult | str) -> list[Prediction]:
             if date is None:
                 continue
 
-            if date.year > 2025 or date.year < 2015:
+            if not is_plausible_expiration_date(date):
                 continue
 
             # Format dates according to ISO 8601

--- a/tests/unit/prediction/ocr/test_expiration_date.py
+++ b/tests/unit/prediction/ocr/test_expiration_date.py
@@ -1,0 +1,60 @@
+import datetime
+
+import pytest
+
+from robotoff.prediction.ocr.expiration_date import (
+    MAX_YEARS_IN_FUTURE,
+    MAX_YEARS_IN_PAST,
+    find_expiration_date,
+    is_plausible_expiration_date,
+)
+from robotoff.types import PredictionType
+
+TODAY = datetime.date(2026, 7, 24)
+
+
+@pytest.mark.parametrize(
+    "date,expected",
+    [
+        # in-window dates are plausible
+        (datetime.date(2026, 6, 14), True),
+        (datetime.date(2027, 1, 1), True),
+        (TODAY, True),
+        # boundaries (inclusive)
+        (datetime.date(TODAY.year + MAX_YEARS_IN_FUTURE, 1, 1), True),
+        (datetime.date(TODAY.year - MAX_YEARS_IN_PAST, 12, 31), True),
+        # just outside the window
+        (datetime.date(TODAY.year + MAX_YEARS_IN_FUTURE + 1, 1, 1), False),
+        (datetime.date(TODAY.year - MAX_YEARS_IN_PAST - 1, 12, 31), False),
+    ],
+)
+def test_is_plausible_expiration_date(date, expected):
+    assert is_plausible_expiration_date(date, today=TODAY) is expected
+
+
+def test_is_plausible_expiration_date_defaults_to_today():
+    # A date in the current year must always be plausible, whatever the year the
+    # test runs in (guards against the previous hardcoded-window regression).
+    today = datetime.date.today()
+    assert is_plausible_expiration_date(datetime.date(today.year, 1, 1)) is True
+
+
+def test_find_expiration_date_keeps_current_and_future_years():
+    # Regression test for the hardcoded [2015, 2025] window that silently
+    # dropped every expiration date from 2026 onwards. Build the year relative
+    # to the current date so this test stays valid in future years.
+    next_year = datetime.date.today().year + 1
+    predictions = find_expiration_date(
+        f"À consommer de préférence avant 14.06.{next_year}"
+    )
+    assert len(predictions) == 1
+    prediction = predictions[0]
+    assert prediction.type == PredictionType.expiration_date
+    # value is normalized to ISO 8601
+    assert prediction.value == f"{next_year}-06-14"
+
+
+def test_find_expiration_date_drops_implausible_years():
+    # A year far in the past is OCR noise and must be discarded.
+    old_year = datetime.date.today().year - (MAX_YEARS_IN_PAST + 10)
+    assert find_expiration_date(f"lot 14.06.{old_year}") == []


### PR DESCRIPTION
## Problem

The expiration-date OCR extractor discarded any detected date whose year was outside a hardcoded window:

```python
if date.year > 2025 or date.year < 2015:
    continue
```

The upper bound (2025) is now in the past, so every valid expiration / best-before date from **2026 onwards** - the common case for products currently on shelves - was silently dropped, producing no `expiration_date` prediction.

### Reproduction

```python
from robotoff.prediction.ocr.expiration_date import find_expiration_date
find_expiration_date("À consommer de préférence avant 14.06.2026")  # -> []  (expected: 1 prediction)
```

## Fix

Replace the hardcoded bounds with a window computed **relative to the current date** (`MAX_YEARS_IN_PAST` / `MAX_YEARS_IN_FUTURE` around today), extracted into a small, testable helper `is_plausible_expiration_date()`. This preserves the OCR-noise filtering (implausible far-past / far-future years are still rejected) while no longer going stale as years pass.

## Tests

Added `tests/unit/prediction/ocr/test_expiration_date.py`:
- boundary and in/out-of-window cases for `is_plausible_expiration_date`
- a regression test asserting a near-future-year date (built relative to `today`, so it can't rot) is now kept and normalized to ISO 8601
- an implausible far-past year is still discarded

```
uv run pytest tests/unit/prediction/ocr/test_expiration_date.py -> 10 passed
uv run ruff check / ruff format / mypy -> clean
```

Fixes #1914