### PR TITLE
fix(insights): delete stale insights on refresh when predictions are gone

### DIFF
--- a/robotoff/insights/importer.py
+++ b/robotoff/insights/importer.py
@@ -2465,12 +2465,23 @@ def refresh_insights(
         for p in get_product_predictions([product_id.barcode], product_id.server_type)
     ]
     prediction_types = set(p.type for p in predictions)
+    # Insight types for which the product still has non-annotated insights.
+    # Even if no prediction of the required type remains, the corresponding
+    # importer must run so that insights that are no longer valid get deleted
+    # (e.g. a pending brand insight after the brand was filled on the product,
+    # #1349). Without this, such stale insights would linger forever, as the
+    # importer was previously skipped whenever its required predictions were
+    # absent.
+    existing_insight_types = get_product_insight_types(product_id)
 
     import_results = []
     for importer in IMPORTERS:
         required_prediction_types = importer.get_required_prediction_types()
         input_prediction_types = importer.get_input_prediction_types()
-        if prediction_types >= required_prediction_types:
+        if (
+            prediction_types >= required_prediction_types
+            or importer.get_type() in existing_insight_types
+        ):
             import_result = importer.import_insights(
                 product_id,
                 [p for p in predictions if p.type in input_prediction_types],
@@ -2478,6 +2489,25 @@ def refresh_insights(
             )
             import_results.append(import_result)
     return import_results
+
+
+def get_product_insight_types(product_id: ProductIdentifier) -> set[InsightType]:
+    """Return the set of insight types for which the product has at least one
+    non-annotated insight in DB.
+
+    :param product_id: identifier of the product
+    :return: a set of `InsightType`
+    """
+    return set(
+        InsightType[row.type]
+        for row in ProductInsight.select(ProductInsight.type)
+        .where(
+            ProductInsight.barcode == product_id.barcode,
+            ProductInsight.server_type == product_id.server_type.name,
+            ProductInsight.annotation.is_null(),
+        )
+        .distinct()
+    )
 
 
 def get_product_predictions(

--- a/tests/unit/insights/test_importer.py
+++ b/tests/unit/insights/test_importer.py
@@ -26,6 +26,7 @@ from robotoff.insights.importer import (
     is_recent_image,
     is_selected_image,
     is_valid_insight_image,
+    refresh_insights,
     select_deepest_taxonomized_candidates,
 )
 from robotoff.models import ProductInsight
@@ -3022,3 +3023,59 @@ class TestIngredientSpellcheckImporter:
             IngredientSpellcheckImporter._keep_prediction(prediction, product)
             is expected
         )
+
+
+class TestRefreshInsights:
+    def test_refresh_insights_runs_importer_with_existing_insight_no_prediction(
+        self, mocker
+    ):
+        """#1349: an importer must run during a refresh when the product still
+        has non-annotated insights of its type, even if no prediction of its
+        required type remains, so that stale insights (e.g. a brand insight
+        after the brand was filled) get deleted. Importers whose type has
+        neither predictions nor existing insights must not run.
+        """
+        mocker.patch(
+            "robotoff.insights.importer.get_product_predictions", return_value=[]
+        )
+        mocker.patch(
+            "robotoff.insights.importer.get_product_insight_types",
+            return_value={InsightType.brand},
+        )
+        brand_import_mock = mocker.patch.object(
+            BrandInsightImporter, "import_insights", return_value="brand-result"
+        )
+        label_import_mock = mocker.patch.object(
+            LabelInsightImporter, "import_insights", return_value="label-result"
+        )
+
+        results = refresh_insights(DEFAULT_PRODUCT_ID, product_store={})
+
+        # The brand importer runs (so it can delete the stale insight)...
+        brand_import_mock.assert_called_once()
+        assert brand_import_mock.call_args.args[0] == DEFAULT_PRODUCT_ID
+        # ...it is called with an empty prediction list (no prediction remains).
+        assert brand_import_mock.call_args.args[1] == []
+        # ...but the label importer, with neither prediction nor existing
+        # insight, is left untouched.
+        label_import_mock.assert_not_called()
+        assert "brand-result" in results
+
+    def test_refresh_insights_skips_importer_without_prediction_or_insight(
+        self, mocker
+    ):
+        """When the product has neither predictions nor existing insights of a
+        type, the corresponding importer must not run (unchanged behaviour)."""
+        mocker.patch(
+            "robotoff.insights.importer.get_product_predictions", return_value=[]
+        )
+        mocker.patch(
+            "robotoff.insights.importer.get_product_insight_types",
+            return_value=set(),
+        )
+        brand_import_mock = mocker.patch.object(BrandInsightImporter, "import_insights")
+
+        results = refresh_insights(DEFAULT_PRODUCT_ID, product_store={})
+
+        brand_import_mock.assert_not_called()
+        assert results == []


### PR DESCRIPTION
## Problem

Addresses one path in #1349.

`refresh_insights()` re-imports insights for a product based on the predictions currently in DB. It only ran an importer when the product still had **predictions of that importer's required type**:

```python
if prediction_types >= required_prediction_types:
    importer.import_insights(...)
```

So if an importer's required prediction no longer exists in DB, the importer is skipped entirely and its non-annotated insight is never re-evaluated or deleted — even when it has become invalid (e.g. a brand insight left in DB after the brand was filled on the product, as reported in #1349).

(When the importer *does* run, deletion already works: `generate_candidates` returns nothing for a product that already has the field, and `get_insight_update` moves the non-annotated reference insight to the delete list.)

## Fix

Also run an importer during refresh when the product still has **non-annotated insights of its type**. It then runs with an empty candidate set and the existing `get_insight_update` logic deletes the stale reference insight; annotated / soon-to-be-auto-applied insights are kept exactly as before. A single-query helper `get_product_insight_types()` returns the insight types with pending insights for the product.

## Caveats / open questions (would appreciate maintainer input)

- **I could not reproduce the exact #1349 history locally** (it needs the production DB state). If brand predictions actually persist after the field is filled, the importer would already run and delete the insight under the current code — in which case the real cause is elsewhere (e.g. `refresh_insights` not being triggered on that update). This PR fixes the **no-remaining-prediction** path and is a no-op whenever the required predictions are present.
- This changes refresh behaviour for **all** importer types, not just brand. That looks aligned with refresh's "reflect current predictions" intent, but flagging in case any insight type is expected to legitimately outlive its backing predictions.

## Tests

Added `TestRefreshInsights` in `tests/unit/insights/test_importer.py`:
- an importer whose type has a pending insight but **no** prediction is now invoked (with an empty prediction list) so it can delete the stale insight; an unrelated importer with neither prediction nor insight is left untouched
- the unchanged path: with no predictions and no existing insights, no importer runs

```
uv run pytest tests/unit/insights/test_importer.py -> 174 passed
uv run ruff check / ruff format / mypy -> clean
```
(Integration tests need a DB and were not run locally — relying on CI.)