### PR TITLE
fix: anchor nutrient mention regex alternatives on word boundaries

### DIFF
--- a/robotoff/prediction/ocr/nutrient.py
+++ b/robotoff/prediction/ocr/nutrient.py
@@ -72,8 +72,7 @@ NUTRIENT_MENTION: dict[str, list[NutrientMentionType]] = {
     ],
     "carbohydrate": [
         ("total carbohydrate", ["en"]),
-        ("glucids?", ["fr"]),
-        ("glucides?", ["en"]),
+        ("glucides?", ["fr"]),
         ("carboidrati", ["it"]),
         ("koolhydraten", ["nl"]),
         ("koolhydraat", ["nl"]),
@@ -157,7 +156,7 @@ def generate_nutrient_mention_regex(nutrient_mentions: list[NutrientMentionType]
         r"(?P<{}>{})".format("{}_{}".format("_".join(lang), i), name)
         for i, (name, lang) in enumerate(nutrient_mentions)
     )
-    return re.compile(rf"(?<!\w){sub_re}(?!\w)", re.I)
+    return re.compile(rf"(?<!\w)(?:{sub_re})(?!\w)", re.I)
 
 
 NUTRIENT_VALUES_REGEX = {

--- a/tests/unit/prediction/ocr/test_nutrient.py
+++ b/tests/unit/prediction/ocr/test_nutrient.py
@@ -26,6 +26,10 @@ from robotoff.types import JSONType
             "acides gras saturés 3.8g waarvan verzadigde",
             {"saturated_fat": [{"languages": ["fr"]}, {"languages": ["nl"]}]},
         ),
+        (
+            "Glucides: 25 g",
+            {"carbohydrate": [{"raw": "Glucides", "languages": ["fr"]}]},
+        ),
     ],
 )
 def test_find_nutrient_mentions(text: str, nutrients: dict[str, list[JSONType]]):
@@ -41,3 +45,17 @@ def test_find_nutrient_mentions(text: str, nutrients: dict[str, list[JSONType]])
             for k, v in ref.items():
                 assert k in current
                 assert current[k] == v
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "basalt",
+        "unsalted",
+        "wholesale",
+        "selon la recette",
+        "fibreglass",
+    ],
+)
+def test_find_nutrient_mentions_no_partial_word_match(text: str):
+    assert find_nutrient_mentions(text) == []


### PR DESCRIPTION
`generate_nutrient_mention_regex()` joins the translated mention patterns with `|` and puts `(?<!\w)` in front and `(?!\w)` at the end. The alternation is never wrapped in a group. So the lookbehind only guards the first alternative and the lookahead only the last. Compiled pattern for salt:

```
(?<!\w)(?P<fr_0>sel)|(?P<en_da_1>salt)|(?P<nl_2>zout)|(?P<de_3>salz)|(?P<it_4>sale)|(?P<es_pt_5>sal)|(?P<hu_6>só)(?!\w)
```

Every middle alternative matches inside longer words. On current main:

```
'salade de tomates' -> salt: [('sal', ['es', 'pt'])]
'unsalted' -> salt: [('salt', ['en', 'da'])]
'Glucides: 25 g' -> carbohydrate: [('Glucid', ['fr'])]
```

`NutritionImageImporter` counts these mentions per language to pick nutrition images. "salade" on a French label credits es and pt with a salt mention. The truncated `Glucid` span also feeds the crop bounding box.

Fix: wrap the alternation in a non-capturing group. On its own that flips "Glucides" to an en match, because `glucids?` can no longer match part of the word and the engine falls through to the next alternative, `glucides?`, which is tagged en. The tags on that pair are the wrong way round, since `glucides` is the French spelling, and the fixture in tests/unit/insights/test_importer.py already assumes glucides is fr. So I dropped `glucids?` and tagged `glucides?` fr. English keeps `total carbohydrate`. `generate_nutrient_regex()` already parenthesizes and is untouched.

Added tests for the substring cases and the full-word fr match. As in #1909 I have no docker dev environment here, so I ran pytest directly on Python 3.12:

```
$ pytest tests/unit/prediction/ocr/test_nutrient.py -q
16 passed in 0.35s
```

The other tests/unit failures in my checkout are already there on unmodified main, and the failing set is identical on both sides. The only difference is the 6 new tests passing here.

Dropping `glucids?` does give up the match on "glucid" and "glucids". Happy to keep it as an en entry instead, or to split the whole glucides correction into its own commit.
