### PR TITLE
fix: add nova group taxonomy URL

### DIFF
--- a/robotoff/settings.py
+++ b/robotoff/settings.py
@@ -164,6 +164,8 @@ TAXONOMY_URLS = {
     + "/data/taxonomies/packaging_recycling.full.json",
     "allergen": BaseURLProvider.static(ServerType.off)
     + "/data/taxonomies/allergen.full.json",
+    "nova_group": BaseURLProvider.static(ServerType.off)
+    + "/data/taxonomies/nova_groups.full.json",
 }
 
 _off_password = os.environ.get("OFF_PASSWORD", "")

--- a/tests/unit/test_taxonomy.py
+++ b/tests/unit/test_taxonomy.py
@@ -1,6 +1,14 @@
 import pytest
 
+from robotoff import settings
 from robotoff.taxonomy import TaxonomyType, match_taxonomized_value
+
+
+def test_nova_group_taxonomy_url():
+    assert "nova_group" in settings.TAXONOMY_URLS
+    assert settings.TAXONOMY_URLS["nova_group"].endswith(
+        "/data/taxonomies/nova_groups.full.json"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What

Add the missing `nova_group` taxonomy URL mapping to `TAXONOMY_URLS`.

A unit test was also added to verify that the `nova_group` taxonomy points to `nova_groups.full.json`.

### Screenshot

Not applicable — this change does not affect the UI.

### Fixes bug(s)

- Closes #1927

### Part of

- N/A