### PR TITLE
fix(ocr): add missing Portuguese nutrient vocabulary and fix regex wo…

### DIFF
--- a/robotoff/prediction/ocr/nutrient.py
+++ b/robotoff/prediction/ocr/nutrient.py
@@ -12,7 +12,7 @@ from robotoff.types import JSONType, Prediction, PredictionType
 
 # Increase version ID when introducing breaking change: changes for which we
 # want old predictions to be removed in DB and replaced by newer ones
-PREDICTOR_VERSION = "1"
+PREDICTOR_VERSION = "2"
 
 
 NutrientMentionType = tuple[str, list[str]]
@@ -55,6 +55,7 @@ NUTRIENT_MENTION: dict[str, list[NutrientMentionType]] = {
         ("vetten", ["nl"]),
         ("fett", ["de"]),
         ("grasas", ["es"]),
+        ("gorduras?", ["pt"]),
         ("grassi", ["it"]),
         ("l[íi]pidos", ["es", "pt"]),
         ("fedt", ["da"]),
@@ -67,6 +68,7 @@ NUTRIENT_MENTION: dict[str, list[NutrientMentionType]] = {
         ("suikers?", ["nl"]),
         ("zucker", ["de"]),
         ("az[úu]cares", ["es"]),
+        ("a[çc][úu]cares", ["pt"]),
         ("sukkerarter", ["da"]),
         ("amelyb[őö]l? cukrok", ["hu"]),
     ],
@@ -105,7 +107,9 @@ NUTRIENT_MENTION: dict[str, list[NutrientMentionType]] = {
         ("fibres? alimentaires?", ["fr"]),
         ("(?:voedings)?vezels?", ["nl"]),
         ("ballaststoffe", ["de"]),
-        ("fibra(?: alimentaria)?", ["es"]),
+        ("fibra alimentar", ["pt"]),
+        ("fibra alimentaria", ["es"]),
+        ("fibra", ["es", "pt"]),
         ("kostfibre", ["da"]),
         ("rost", ["hu"]),
     ],
@@ -157,7 +161,7 @@ def generate_nutrient_mention_regex(nutrient_mentions: list[NutrientMentionType]
         r"(?P<{}>{})".format("{}_{}".format("_".join(lang), i), name)
         for i, (name, lang) in enumerate(nutrient_mentions)
     )
-    return re.compile(rf"(?<!\w){sub_re}(?!\w)", re.I)
+    return re.compile(rf"(?<!\w)(?:{sub_re})(?!\w)", re.I)
 
 
 NUTRIENT_VALUES_REGEX = {

--- a/tests/unit/prediction/ocr/test_nutrient.py
+++ b/tests/unit/prediction/ocr/test_nutrient.py
@@ -26,6 +26,16 @@ from robotoff.types import JSONType
             "acides gras saturés 3.8g waarvan verzadigde",
             {"saturated_fat": [{"languages": ["fr"]}, {"languages": ["nl"]}]},
         ),
+        # Regression tests for #1417 (also covers the regex-boundary fix
+        # in generate_nutrient_mention_regex): pt vocabulary for fat/sugar
+        # was missing or mistagged as es; fiber cases check that pt- and
+        # es-specific suffixes resolve to their own language while the
+        # bare shared word ("fibra") still resolves to both.
+        ("Gorduras 5g", {"fat": [{"languages": ["pt"]}]}),
+        ("Açúcares 10g", {"sugar": [{"languages": ["pt"]}]}),
+        ("Fibra alimentar 2.5g", {"fiber": [{"languages": ["pt"]}]}),
+        ("Fibra 2.5g", {"fiber": [{"languages": ["es", "pt"]}]}),
+        ("Fibra alimentaria 2.5g", {"fiber": [{"languages": ["es"]}]}),
     ],
 )
 def test_find_nutrient_mentions(text: str, nutrients: dict[str, list[JSONType]]):


### PR DESCRIPTION
### What
Fixes two related bugs causing Portuguese nutrition-table photos to be
misdetected as Spanish (robotoff/prediction/ocr/nutrient.py):

1. Portuguese vocabulary was missing or ambiguously shared with Spanish
   in `NUTRIENT_MENTION` for `fat` (added `gorduras?`), `sugar` (added
   `açúcares`), and `fiber` (split the shared bare `fibra` from the
   Portuguese-specific `fibra alimentar` and Spanish-specific
   `fibra alimentaria` suffixes).
2. `generate_nutrient_mention_regex` joined alternatives with `|`
   without wrapping them in a non-capturing group, so the `(?<!\w)`
   and `(?!\w)` word-boundary checks only applied to the first and
   last alternative in the list, not the ones in between. This let
   middle alternatives spuriously match as substrings of longer words
   (e.g. `fibra alimentar` matching inside `fibra alimentaria`,
   consuming only the shared prefix and leaving the language
   misattributed). This second bug is more general and likely affects
   other nutrient categories too, though it only became visible here
   once overlapping pt/es vocabulary was introduced.

Bumps `PREDICTOR_VERSION` to `2` so existing `nutrient_mention` predictions
are regenerated with the corrected matching.

Added regression tests in `tests/unit/prediction/ocr/test_nutrient.py`
covering the new vocabulary and the es/pt fiber-suffix disambiguation.
Full unit suite passes locally (607 passed).

Note: this does not fully resolve #1417 on its own. The automatic
nutrition-image selection for that issue's product likely goes through
`NutritionImageImporter` (robotoff/insights/importer.py), which can
still tie between "es" and "pt" for labels using only vocabulary shared
between the two languages (e.g. "lípidos", "hidratos de carbono",
"proteínas", "sal"). Tracking that separately.

### Screenshot
N/A (backend/OCR vocabulary and regex changes only, no UI impact).

### Fixes bug(s)
- N/A

### Part of
- #1417
