### PR TITLE
fix(products): fall back to obsolete product collection

### DIFF
--- a/robotoff/products.py
+++ b/robotoff/products.py
@@ -576,6 +576,8 @@ class DBProductStore(ProductStore):
     ) -> JSONType | None:
         """Fetch a product from the MongoDB.
 
+        Search regular products first, then obsolete products if not found.
+
         :param product_id: identifier of the product to fetch
         :param projection: list of fields to retrieve, if not provided all fields
             are queried
@@ -589,6 +591,10 @@ class DBProductStore(ProductStore):
         # barcode for pro platform, which is also the case for
         # `product_id.barcode`
         product = self.collection.find_one({"_id": product_id.barcode}, projection)
+        if product is None:
+            product = self.db.products_obsolete.find_one(
+                {"_id": product_id.barcode}, projection
+            )
 
         # Convert the `images` field to the legacy schema, until the migration
         # is done. Once it's done, we can upgrade all Robotoff code to use the new

--- a/tests/unit/test_products.py
+++ b/tests/unit/test_products.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 from unittest.mock import MagicMock
 
 import pytest
@@ -266,6 +267,7 @@ IMAGES_WITH_NEW_SCHEMA = {
 
 
 class TestDBProductStore:
+    @pytest.mark.parametrize("collection", ["products", "products_obsolete"])
     @pytest.mark.parametrize(
         "barcode,projection,db_output,expected_output",
         [
@@ -319,10 +321,16 @@ class TestDBProductStore:
             ),
         ],
     )
-    def test_get_product(self, barcode, projection, db_output, expected_output):
+    def test_get_product(
+        self, barcode, projection, db_output, expected_output, collection
+    ):
         server_type = ServerType.off
         client = {server_type: MagicMock()}
-        client[server_type].products.find_one.return_value = db_output
+        client[server_type].products.find_one.return_value = None
+        client[server_type].products_obsolete.find_one.return_value = None
+        getattr(client[server_type], collection).find_one.return_value = deepcopy(
+            db_output
+        )
         db = DBProductStore(server_type, client)
 
         product = db.get_product(
@@ -331,11 +339,56 @@ class TestDBProductStore:
         )
         assert product == expected_output
 
-        if projection:
-            assert client[server_type].products.find_one.call_count == 1
-            assert client[server_type].products.find_one.call_args[0][1] == [
-                "product_name"
-            ]
+        client[server_type].products.find_one.assert_called_once_with(
+            {"_id": barcode}, projection
+        )
+        if collection == "products_obsolete":
+            client[server_type].products_obsolete.find_one.assert_called_once_with(
+                {"_id": barcode}, projection
+            )
+        else:
+            client[server_type].products_obsolete.find_one.assert_not_called()
+
+    def test_get_product_not_found(self):
+        database = MagicMock()
+        database.products.find_one.return_value = None
+        database.products_obsolete.find_one.return_value = None
+        db = DBProductStore(ServerType.off, {"off": database})
+        product_id = ProductIdentifier("1234567890", ServerType.off)
+
+        assert db.get_product(product_id) is None
+
+        database.products.find_one.assert_called_once_with({"_id": "1234567890"}, None)
+        database.products_obsolete.find_one.assert_called_once_with(
+            {"_id": "1234567890"}, None
+        )
+
+    def test_get_product_mongodb_disabled(self, mocker):
+        mocker.patch("robotoff.settings.ENABLE_MONGODB_ACCESS", False)
+        database = MagicMock()
+        db = DBProductStore(ServerType.off, {"off": database})
+        product_id = ProductIdentifier("1234567890", ServerType.off)
+
+        assert db.get_product(product_id) is None
+
+        database.products.find_one.assert_not_called()
+        database.products_obsolete.find_one.assert_not_called()
+
+    def test_get_product_obsolete_pro_product(self):
+        database = MagicMock()
+        barcode = "org-lea-nature/3307130803004"
+        product_data = {"_id": barcode, "code": "3307130803004"}
+        database.products.find_one.return_value = None
+        database.products_obsolete.find_one.return_value = product_data
+        db = DBProductStore(ServerType.off_pro, {"off-pro": database})
+        product_id = ProductIdentifier(barcode, ServerType.off_pro)
+
+        assert db.get_product(product_id, projection=["code"]) == product_data
+
+        database.products.find_one.assert_called_once_with({"_id": barcode}, ["code"])
+        database.products_obsolete.find_one.assert_called_once_with(
+            {"_id": barcode}, ["code"]
+        )
 
 
 class TestProduct:


### PR DESCRIPTION
Product Opener moves obsolete products into `products_obsolete`, but Robotoff only looks in `products` when fetching a product by ID. An existing obsolete product is therefore reported as missing.

This change makes `DBProductStore.get_product()` fall back to `products_obsolete` when the regular collection returns `None`. Both lookups use the same `_id` and field projection, and products from either collection pass through the existing legacy-image conversion. A match in the regular collection avoids the extra query.

Regression coverage checks both collections, projected fields, image conversion, missing products, disabled MongoDB access, and organization-prefixed producer-platform IDs. The new fallback cases failed against the original implementation.

Related to #1095. This PR covers direct MongoDB product lookups; the JSONL-dump/nightly-cleanup concern discussed in the issue remains separate.

### Validation

On Python 3.12:

- `pytest tests/unit/test_products.py -q` — 26 passed.
- `pytest tests/unit/workers/tasks/test_import_image.py tests/unit/workers/tasks/test_product_updated.py tests/unit/insights/test_importer.py -q` — 190 passed.
- `ruff check robotoff/products.py tests/unit/test_products.py` — passed.
- `ruff format --check robotoff/products.py tests/unit/test_products.py` — passed.
- `mypy --follow-imports=silent robotoff/products.py` — passed.
- `git diff --check` — passed.

The full Docker/integration suite was not run locally; Docker is unavailable in this environment.